### PR TITLE
fix: bind to localhost only by default for security

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Access your personal AI agents and workstation data anywhere, anytime through Mi
 
 ### Access Modes
 
-- **Local mode**: Accessible in the browser on the local network immediately after startup — no account or configuration needed.
+- **Local mode**: Accessible in the browser on the local machine immediately after startup — no account or configuration needed.
 - **Relay remote mode**: Access your local instance from anywhere on the public internet without opening firewall ports, via an encrypted tunnel through [a9gent.com](https://a9gent.com). Click the bind button in the local UI to activate.
 - **Private channel**: Use a private network (e.g. Tailscale) and access directly via `ip:port`.
 
@@ -138,7 +138,7 @@ MindFS automatically detects the availability of installed agents. This usually 
 mindfs [flags] [root]
 
 Flags:
-  -addr string   Listen address (default ":7331")
+  -addr string   Listen address (default "127.0.0.1:7331")
   -no-relayer    Disable relay integration
   -remove        Unregister a managed directory from a running server
 ```

--- a/cli/cmd/mindfs.go
+++ b/cli/cmd/mindfs.go
@@ -53,7 +53,7 @@ func main() {
 		fmt.Fprintf(out, "  mindfs -remove /path/to/project\n")
 	}
 
-	addr := flag.String("addr", ":7331", "listen address")
+	addr := flag.String("addr", "127.0.0.1:7331", "listen address")
 	noRelayer := flag.Bool("no-relayer", false, "disable relay integration")
 	foreground := flag.Bool("foreground", false, "run in the foreground instead of as a background service")
 	stop := flag.Bool("stop", false, "stop the background mindfs service")

--- a/server/cmd/mindfs-server/main.go
+++ b/server/cmd/mindfs-server/main.go
@@ -14,7 +14,7 @@ import (
 var version = "dev"
 
 func main() {
-	addr := flag.String("addr", ":7331", "listen address")
+	addr := flag.String("addr", "127.0.0.1:7331", "listen address")
 	noRelayer := flag.Bool("no-relayer", false, "disable relay integration")
 	flag.Parse()
 


### PR DESCRIPTION
## Summary

Change default listen address from `:7331` to `127.0.0.1:7331` to prevent unauthorized LAN access without authentication.

## Changes

- `cli/cmd/mindfs.go`: Change default `-addr` from `:7331` to `127.0.0.1:7331`
- `server/cmd/mindfs-server/main.go`: Change default `-addr` from `:7331` to `127.0.0.1:7331`
- `README.md`: Update documentation to reflect the new default behavior

## Rationale

The previous default (`:7331`) listens on all network interfaces, making the service accessible to anyone on the local network without any authentication mechanism. This is a security risk for users who may not realize their MindFS instance is exposed.

By binding to `127.0.0.1` by default:
- The service is only accessible from the local machine
- Users who need LAN access can still explicitly use `-addr :7331`
- Users who need remote access can use the relay mode or private network options

Fixes #7