### PR TITLE
feat(会话): 添加获取当前模型接口及日志跟踪会话流程

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build/
 vendor/
 *.out
 design/
+mindfs

--- a/server/app/server.go
+++ b/server/app/server.go
@@ -68,7 +68,7 @@ func Start(ctx context.Context, addr string, opts StartOptions) error {
 	mux.Handle("/", httpHandler.Routes())
 	mux.Handle("/ws", wsHandler)
 
-	handler := api.LoggingMiddleware(mux)
+	handler := api.LoggingMiddleware(api.CORSMiddleware(mux))
 
 	server := &http.Server{
 		Addr:              addr,
@@ -103,6 +103,12 @@ func resolveStaticDir() string {
 		candidate := filepath.Join(prefix, "share", "mindfs", "web")
 		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
 			return candidate
+		}
+		
+		// Fallback for development (running from workspace root)
+		cwdCandidate := filepath.Join(filepath.Dir(exe), "web", "dist")
+		if info, err := os.Stat(cwdCandidate); err == nil && info.IsDir() {
+			return cwdCandidate
 		}
 	}
 	return ""

--- a/server/internal/agent/acp/session.go
+++ b/server/internal/agent/acp/session.go
@@ -276,6 +276,13 @@ func (s *session) SendMessage(ctx context.Context, content string) error {
 	return s.proc.SendMessage(ctx, s.sessionKey, content)
 }
 
+func (s *session) CurrentModel() string {
+	if s == nil || s.proc == nil {
+		return ""
+	}
+	return strings.TrimSpace(mapModelState(s.proc.SessionModelState(s.sessionKey)).CurrentModelID)
+}
+
 func (s *session) SetModel(ctx context.Context, model string) error {
 	if s == nil || s.proc == nil {
 		return errors.New("acp session not initialized")

--- a/server/internal/agent/claude/session.go
+++ b/server/internal/agent/claude/session.go
@@ -80,19 +80,15 @@ func (r *Runtime) OpenSession(ctx context.Context, opts OpenOptions) (types.Sess
 	}
 
 	selectedModel := strings.TrimSpace(opts.Model)
-	if selectedModel == "" {
-		for _, model := range client.SupportedModelsFromInit() {
-			candidate := strings.TrimSpace(model.Value)
-			if candidate == "" {
-				continue
-			}
-			if err := stream.SetModel(ctx, candidate); err != nil {
-				_ = stream.Close()
-				_ = client.Close()
-				return nil, err
-			}
+	if selectedModel == "" && opts.ResumeSessionID == "" {
+		if candidate, ok := claudeFirstAvailableModel(client); ok {
 			selectedModel = candidate
-			break
+		}
+	}
+	if selectedModel != "" {
+		if err := stream.SetModel(ctx, selectedModel); err != nil {
+			client.Close()
+			return nil, err
 		}
 	}
 
@@ -109,6 +105,20 @@ func (r *Runtime) OpenSession(ctx context.Context, opts OpenOptions) (types.Sess
 }
 
 func (r *Runtime) CloseAll() {}
+
+func claudeFirstAvailableModel(client *claudeagent.Client) (string, bool) {
+	if client == nil {
+		return "", false
+	}
+	for _, item := range client.SupportedModelsFromInit() {
+		candidate := strings.TrimSpace(item.Value)
+		if candidate == "" || strings.EqualFold(candidate, "default") {
+			continue
+		}
+		return candidate, true
+	}
+	return "", false
+}
 
 type session struct {
 	client *claudeagent.Client
@@ -169,6 +179,15 @@ func (s *session) SendMessage(ctx context.Context, content string) error {
 		log.Printf("[agent/claude] send.error session=%s err=%v", s.sessionKey, turnCtx.Err())
 		return turnCtx.Err()
 	}
+}
+
+func (s *session) CurrentModel() string {
+	if s == nil {
+		return ""
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return strings.TrimSpace(s.model)
 }
 
 func (s *session) SetModel(ctx context.Context, model string) error {
@@ -268,14 +287,18 @@ func (s *session) SessionID() string {
 }
 
 func (s *session) CancelCurrentTurn() error {
+	log.Printf("[agent/claude] cancel.begin session=%s", s.sessionKey)
 	if s.stream == nil {
 		s.turn.Cancel()
+		log.Printf("[agent/claude] cancel.done session=%s mode=turn_only", s.sessionKey)
 		return nil
 	}
 	if err := s.stream.Interrupt(context.Background()); err == nil {
+		log.Printf("[agent/claude] cancel.done session=%s mode=interrupt", s.sessionKey)
 		return nil
 	}
 	s.turn.Cancel()
+	log.Printf("[agent/claude] cancel.done session=%s mode=fallback_turn_only", s.sessionKey)
 	return nil
 }
 

--- a/server/internal/agent/codex/session.go
+++ b/server/internal/agent/codex/session.go
@@ -216,6 +216,15 @@ func (s *session) SendMessage(ctx context.Context, content string) error {
 	return nil
 }
 
+func (s *session) CurrentModel() string {
+	if s == nil {
+		return ""
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return strings.TrimSpace(s.threadOpts.Model)
+}
+
 func (s *session) SetModel(_ context.Context, model string) error {
 	if s == nil || s.client == nil {
 		return errors.New("codex session not initialized")

--- a/server/internal/agent/types/types.go
+++ b/server/internal/agent/types/types.go
@@ -12,6 +12,9 @@ type Session interface {
 	// SendMessage sends a message to the current session.
 	SendMessage(ctx context.Context, content string) error
 
+	// CurrentModel returns the model currently used by the runtime session.
+	CurrentModel() string
+
 	// SetModel updates the model used by the current session.
 	SetModel(ctx context.Context, model string) error
 

--- a/server/internal/api/http.go
+++ b/server/internal/api/http.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"mime"
@@ -732,6 +733,9 @@ func (h *HTTPHandler) handleFile(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", mimeType)
 		} else {
 			w.Header().Set("Content-Type", "application/octet-stream")
+		}
+		if r.URL.Query().Get("download") == "1" {
+			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filepath.Base(rawOut.RelPath)))
 		}
 		w.WriteHeader(http.StatusOK)
 		io.Copy(w, rawOut.File)

--- a/server/internal/api/logging.go
+++ b/server/internal/api/logging.go
@@ -59,3 +59,28 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		)
 	})
 }
+
+// CORSMiddleware adds CORS and Private Network Access headers to all HTTP responses.
+// This enables the Capacitor App WebView (and browser) to make cross-origin requests
+// from origins like https://localhost or http://localhost to the MindFS API server.
+func CORSMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			origin = "*"
+		}
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Requested-With")
+		// Private Network Access header: allows WebView (secure context) to reach local network resources
+		w.Header().Set("Access-Control-Allow-Private-Network", "true")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/internal/api/usecase/session.go
+++ b/server/internal/api/usecase/session.go
@@ -993,6 +993,7 @@ func (s *Service) SendMessage(ctx context.Context, in SendMessageInput) error {
 		log.Printf("[session/model] validate.error root=%s session=%s agent=%s model=%q err=%v", in.RootID, in.Key, strings.TrimSpace(in.Agent), strings.TrimSpace(in.Model), err)
 		return err
 	}
+	log.Printf("[session] turn.begin root=%s session=%s agent=%s model=%q", in.RootID, in.Key, strings.TrimSpace(in.Agent), strings.TrimSpace(in.Model))
 	turnCtx, turnCancel := context.WithCancel(ctx)
 	registerActiveTurn(in.RootID, in.Key, turnCancel)
 	defer unregisterActiveTurn(in.RootID, in.Key)
@@ -1074,15 +1075,24 @@ func (s *Service) SendMessage(ctx context.Context, in SendMessageInput) error {
 		}
 	})
 	sendErr := sess.SendMessage(turnCtx, prompt)
-	if err := manager.UpdateModel(ctx, current, in.Model); err != nil {
+	if sendErr != nil {
+		log.Printf("[session] turn.send.error root=%s session=%s agent=%s err=%v", in.RootID, current.Key, in.Agent, sendErr)
+	}
+	persistedModel := strings.TrimSpace(in.Model)
+	if persistedModel == "" {
+		persistedModel = sess.CurrentModel()
+	}
+	if err := manager.UpdateModel(ctx, current, persistedModel); err != nil {
 		return err
 	}
 	resolvedMode := resolveRuntimeMode(current, in.Mode)
 	resolvedEffort := resolveRuntimeEffort(in.Agent, current, in.Effort)
 	if err := manager.AddExchangeForAgent(ctx, current, "user", in.Content, in.Agent, resolvedMode, resolvedEffort); err != nil {
+		log.Printf("[session] persist.user.error root=%s session=%s agent=%s err=%v", in.RootID, current.Key, in.Agent, err)
 		return err
 	}
 	if err := manager.AddExchangeForAgent(ctx, current, "agent", responseText, in.Agent, resolvedMode, resolvedEffort); err != nil {
+		log.Printf("[session] persist.agent.error root=%s session=%s agent=%s err=%v", in.RootID, current.Key, in.Agent, err)
 		return err
 	}
 	if err := manager.UpdateAgentState(ctx, current, in.Agent, contextLineCount(current.Exchanges), sess.SessionID()); err != nil {
@@ -1097,6 +1107,11 @@ func (s *Service) SendMessage(ctx context.Context, in SendMessageInput) error {
 		return sendErr
 	} else if prober != nil {
 		prober.ReportSuccess(in.Agent)
+	}
+	if isCanceledTurnError(sendErr) {
+		log.Printf("[session] turn.canceled root=%s session=%s agent=%s", in.RootID, current.Key, in.Agent)
+	} else {
+		log.Printf("[session] turn.complete root=%s session=%s agent=%s", in.RootID, current.Key, in.Agent)
 	}
 
 	return nil
@@ -1268,11 +1283,17 @@ func (s *Service) CancelSessionTurn(ctx context.Context, in CancelSessionTurnInp
 	}
 	active := getActiveTurn(in.RootID, current.Key)
 	if active == nil {
+		log.Printf("[session] turn.cancel.skip root=%s session=%s reason=no_active_turn", in.RootID, current.Key)
 		return nil
 	}
+	log.Printf("[session] turn.cancel.begin root=%s session=%s", in.RootID, current.Key)
 	active.cancel()
 	if active.session != nil {
-		return active.session.CancelCurrentTurn()
+		if err := active.session.CancelCurrentTurn(); err != nil {
+			log.Printf("[session] turn.cancel.error root=%s session=%s err=%v", in.RootID, current.Key, err)
+			return err
+		}
 	}
+	log.Printf("[session] turn.cancel.done root=%s session=%s", in.RootID, current.Key)
 	return nil
 }

--- a/server/internal/api/ws.go
+++ b/server/internal/api/ws.go
@@ -310,6 +310,7 @@ func (h *WSHandler) handleSessionMessage(ctx context.Context, conn *websocket.Co
 	agentMode := getString(req.Payload, "agent_mode")
 	effort := getString(req.Payload, "effort")
 	requestID := strings.TrimSpace(req.ID)
+	log.Printf("[ws] session.message.begin root=%s session=%s request=%s type=%s agent=%s model=%q client=%s", rootID, key, requestID, sessionType, agentName, model, clientID)
 	if content == "" || sessionType == "" || agentName == "" {
 		h.sendWSError(conn, req.ID, "invalid_request", "content, type and agent required")
 		return
@@ -393,12 +394,15 @@ func (h *WSHandler) handleSessionMessage(ctx context.Context, conn *websocket.Co
 		},
 	})
 	if err != nil {
+		log.Printf("[ws] session.message.error root=%s session=%s request=%s err=%v", rootID, key, req.ID, err)
 		errorMessage := normalizeAgentErrorMessage(err)
 		event := &StreamEvent{
 			Type: "error",
 			Data: map[string]string{"message": errorMessage},
 		}
 		streamHub.BroadcastSessionStream(rootID, key, event)
+	} else {
+		log.Printf("[ws] session.message.success root=%s session=%s request=%s", rootID, key, req.ID)
 	}
 	streamHub.ClearSessionPending(key)
 
@@ -444,8 +448,11 @@ func (h *WSHandler) handleSessionCancel(ctx context.Context, conn *websocket.Con
 		RootID: rootID,
 		Key:    key,
 	}); err != nil {
+		log.Printf("[ws] session.cancel.error root=%s session=%s request=%s err=%v", rootID, key, req.ID, err)
 		h.sendWSError(conn, req.ID, "session.cancel_failed", err.Error())
+		return
 	}
+	log.Printf("[ws] session.cancel.done root=%s session=%s request=%s", rootID, key, req.ID)
 }
 
 func (h *WSHandler) sendWSError(conn *websocket.Conn, id, code, message string) {

--- a/server/internal/session/manager.go
+++ b/server/internal/session/manager.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -302,6 +303,7 @@ func (m *Manager) AddExchangeForAgent(_ context.Context, session *Session, role,
 		Timestamp: m.now().UTC(),
 	}
 	if err := m.appendExchange(session.Key, record); err != nil {
+		log.Printf("[session/store] append.error session=%s seq=%d role=%s agent=%s err=%v", session.Key, record.Seq, role, resolvedAgent, err)
 		return err
 	}
 	session.Exchanges = append(session.Exchanges, record)


### PR DESCRIPTION
- 添加获取当前模型接口并完善模型处理逻辑, 解决使用自定义API接入的模型找不到问题
- 添加日志记录以跟踪会话和取消流程，增加本地cors加载适配，方便排查问题