### PR TITLE
feat: add HTTPS support with self-signed certificate generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,23 @@ mindfs -addr :9000 /path/to/your/project  # custom port
 
 Open [http://localhost:7331](http://localhost:7331) in your browser.
 
+#### HTTPS (TLS)
+
+Enable HTTPS with a self-signed certificate (auto-generated and reused across restarts):
+
+```bash
+mindfs -tls
+mindfs -tls -addr :9000 /path/to/your/project
+```
+
+Open [https://localhost:7331](https://localhost:7331) in your browser. The auto-generated certificate includes SANs for `localhost`, `127.0.0.1`, `::1`, and all non-loopback interface IPs, so LAN clients can connect without certificate name mismatches. Certificates are stored under the user config directory (e.g., `~/.config/mindfs/` on Linux).
+
+Use custom certificate and key files:
+
+```bash
+mindfs -tls -cert /path/to/cert.pem -key /path/to/key.pem
+```
+
 MindFS automatically detects the availability of installed agents. This usually takes about one minute.
 
 ### Enable Remote Access (Optional)
@@ -146,6 +163,9 @@ Flags:
   -addr string   Listen address (default "127.0.0.1:7331")
   -no-relayer    Disable relay integration
   -remove        Unregister a managed directory from a running server
+  -tls           Enable HTTPS (auto-generates self-signed cert if -cert/-key not provided)
+  -cert string   TLS certificate file (PEM); requires -tls
+  -key string    TLS private key file (PEM); requires -tls
 ```
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -129,6 +129,23 @@ mindfs -addr :9000 /path/to/your/project # 指定端口
 
 在浏览器中打开（默认端口） [http://localhost:7331](http://localhost:7331)。
 
+#### HTTPS (TLS)
+
+启用 HTTPS，使用自动生成的自签名证书（重启后可复用）：
+
+```bash
+mindfs -tls
+mindfs -tls -addr :9000 /path/to/your/project
+```
+
+在浏览器中打开 [https://localhost:7331](https://localhost:7331)。自动生成的证书包含 `localhost`、`127.0.0.1`、`::1` 以及所有非回环网卡 IP 的 SAN，局域网内其他设备访问时不会出现证书名称不匹配警告。证书存储在用户配置目录下（如 Linux 的 `~/.config/mindfs/`）。
+
+使用自定义证书和私钥文件：
+
+```bash
+mindfs -tls -cert /path/to/cert.pem -key /path/to/key.pem
+```
+
 MindFS 会自动探测已安装 Agent 的可用性，通常需要大约一分钟。
 
 ### 通过 relayer远程访问
@@ -146,6 +163,9 @@ Flags:
   -addr string   监听地址（默认 ":7331"）
   -no-relayer    禁用 Relay 集成
   -remove        从运行中的服务器移除托管目录
+  -tls           启用 HTTPS（如未指定 -cert/-key，则自动生成自签名证书）
+  -cert string   TLS 证书文件（PEM）；需配合 -tls 使用
+  -key string    TLS 私钥文件（PEM）；需配合 -tls 使用
 ```
 
 ---

--- a/cli/cmd/mindfs.go
+++ b/cli/cmd/mindfs.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -63,6 +64,9 @@ func main() {
 	restart := flag.Bool("restart", false, "restart the background mindfs service")
 	statusFlag := flag.Bool("status", false, "show background service status")
 	remove := flag.Bool("remove", false, "remove the managed directory")
+	tlsFlag := flag.Bool("tls", false, "enable HTTPS (auto-generates self-signed cert if -cert/-key not provided)")
+	certFlag := flag.String("cert", "", "TLS certificate file (PEM); auto-generated if empty with -tls")
+	keyFlag := flag.String("key", "", "TLS private key file (PEM); auto-generated if empty with -tls")
 	flag.Parse()
 	internalRestart := os.Getenv(internalRestartEnvKey) == "1"
 	daemonMode := os.Getenv(daemonEnvKey) == "1"
@@ -91,14 +95,14 @@ func main() {
 	}
 
 	if *statusFlag {
-		if err := printServiceStatus(*addr, pidPath, logPath); err != nil {
+		if err := printServiceStatus(*addr, *tlsFlag, pidPath, logPath); err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 		return
 	}
 	if *stop {
-		if err := stopService(*addr, pidPath); err != nil {
+		if err := stopService(*addr, *tlsFlag, pidPath); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				fmt.Fprintln(os.Stdout, "mindfs service already stopped")
 				return
@@ -110,14 +114,14 @@ func main() {
 		return
 	}
 	if *restart {
-		if err := stopService(*addr, pidPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := stopService(*addr, *tlsFlag, pidPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	}
 
 	if *remove {
-		if err := handleRemoveRoot(*addr, absRoot); err != nil {
+		if err := handleRemoveRoot(*addr, *tlsFlag, absRoot); err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
@@ -135,18 +139,28 @@ func main() {
 		fmt.Fprintln(os.Stdout, "pairing secret:", e2eeResult.Config.PairingSecret)
 	}
 
-	if !internalRestart && !*restart && serverRunning(*addr) {
+	if !internalRestart && !*restart && serverRunning(*addr, *tlsFlag) {
 		fmt.Fprintf(os.Stdout, "server already running on %s, reusing existing process\n", *addr)
-		rootInfo, err := addManagedDir(*addr, absRoot)
+		rootInfo, err := addManagedDir(*addr, *tlsFlag, absRoot)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 		fmt.Fprintln(os.Stdout, "added managed directory:", rootInfo.RootPath)
-		if err := openTarget(*addr, rootInfo.ID); err != nil {
+		if err := openTarget(*addr, *tlsFlag, rootInfo.ID); err != nil {
 			reportOpenTargetError(os.Stderr, err)
 		}
 		return
+	}
+
+	// Resolve TLS certificate/key paths when TLS is enabled.
+	resolvedCert, resolvedKey := *certFlag, *keyFlag
+	if *tlsFlag && (resolvedCert == "" || resolvedKey == "") {
+		resolvedCert, resolvedKey, err = app.EnsureTLSCert(*certFlag, *keyFlag)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
 	}
 
 	if !*foreground && !daemonMode && !internalRestart {
@@ -154,18 +168,18 @@ func main() {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
-		if err := waitForServer(*addr, 8*time.Second); err != nil {
+		if err := waitForServer(*addr, *tlsFlag, 8*time.Second); err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
-		rootInfo, err := addManagedDir(*addr, absRoot)
+		rootInfo, err := addManagedDir(*addr, *tlsFlag, absRoot)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 		fmt.Fprintln(os.Stdout, "mindfs service started")
 		fmt.Fprintln(os.Stdout, "added managed directory:", rootInfo.RootPath)
-		if err := openTarget(*addr, rootInfo.ID); err != nil {
+		if err := openTarget(*addr, *tlsFlag, rootInfo.ID); err != nil {
 			reportOpenTargetError(os.Stderr, err)
 		}
 		fmt.Fprintf(os.Stdout, "logs: %s\n", logPath)
@@ -187,14 +201,17 @@ func main() {
 			Version:    version,
 			Args:       os.Args[1:],
 			E2EEConfig: e2eeResult.Config,
+			UseTLS:     *tlsFlag,
+			CertFile:   resolvedCert,
+			KeyFile:    resolvedKey,
 		})
 	}()
-	if err := waitForServer(*addr, 8*time.Second); err != nil {
+	if err := waitForServer(*addr, *tlsFlag, 8*time.Second); err != nil {
 		cancel()
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
-	rootInfo, err := addManagedDir(*addr, absRoot)
+	rootInfo, err := addManagedDir(*addr, *tlsFlag, absRoot)
 	if err != nil {
 		cancel()
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -203,7 +220,7 @@ func main() {
 	fmt.Fprintln(os.Stdout, "added managed directory:", rootInfo.RootPath)
 
 	if !internalRestart && (*foreground || !daemonMode) {
-		if err := openTarget(*addr, rootInfo.ID); err != nil {
+		if err := openTarget(*addr, *tlsFlag, rootInfo.ID); err != nil {
 			reportOpenTargetError(os.Stderr, err)
 		}
 	}
@@ -346,8 +363,8 @@ func readPIDFile(pidPath string) (int, error) {
 	return pid, nil
 }
 
-func stopService(addr, pidPath string) error {
-	pid, err := resolveServicePID(addr, pidPath)
+func stopService(addr string, useTLS bool, pidPath string) error {
+	pid, err := resolveServicePID(addr, useTLS, pidPath)
 	if err != nil {
 		return err
 	}
@@ -372,8 +389,8 @@ func stopService(addr, pidPath string) error {
 	return fmt.Errorf("timed out stopping process %d", pid)
 }
 
-func printServiceStatus(addr, pidPath, logPath string) error {
-	pid, err := resolveServicePID(addr, pidPath)
+func printServiceStatus(addr string, useTLS bool, pidPath, logPath string) error {
+	pid, err := resolveServicePID(addr, useTLS, pidPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			fmt.Fprintln(os.Stdout, "mindfs status: stopped")
@@ -383,12 +400,12 @@ func printServiceStatus(addr, pidPath, logPath string) error {
 	}
 	fmt.Fprintln(os.Stdout, "mindfs status: running")
 	fmt.Fprintf(os.Stdout, "pid: %d\n", pid)
-	fmt.Fprintf(os.Stdout, "addr: %s\n", addrToURL(addr, ""))
+	fmt.Fprintf(os.Stdout, "addr: %s\n", addrToURL(addr, "", useTLS))
 	fmt.Fprintf(os.Stdout, "log file: %s\n", logPath)
 	return nil
 }
 
-func resolveServicePID(addr, pidPath string) (int, error) {
+func resolveServicePID(addr string, useTLS bool, pidPath string) (int, error) {
 	pid, err := readPIDFile(pidPath)
 	if err == nil {
 		if processExists(pid) {
@@ -399,7 +416,7 @@ func resolveServicePID(addr, pidPath string) (int, error) {
 		return 0, err
 	}
 
-	if strings.TrimSpace(addr) == "" || !serverRunning(addr) {
+	if strings.TrimSpace(addr) == "" || !serverRunning(addr, useTLS) {
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return 0, err
 		}
@@ -426,9 +443,22 @@ func processExists(pid int) bool {
 	return processExistsPlatform(pid)
 }
 
-func serverRunning(addr string) bool {
-	url := addrToURL(addr, "/health")
-	client := &http.Client{Timeout: 800 * time.Millisecond}
+func newHTTPClient(useTLS bool, timeout time.Duration) *http.Client {
+	c := &http.Client{Timeout: timeout}
+	if useTLS {
+		// InsecureSkipVerify is used because these CLI health checks and API
+		// calls connect to the local MindFS server (loopback or same machine),
+		// which may present a self-signed certificate. No traffic leaves the host.
+		c.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+	return c
+}
+
+func serverRunning(addr string, useTLS bool) bool {
+	url := addrToURL(addr, "/health", useTLS)
+	client := newHTTPClient(useTLS, 800*time.Millisecond)
 	resp, err := client.Get(url)
 	if err != nil {
 		return false
@@ -451,8 +481,8 @@ type relayStatusResponse struct {
 	NodeURL      string `json:"node_url"`
 }
 
-func addManagedDir(addr, path string) (managedDirResponse, error) {
-	url := addrToURL(addr, "/api/dirs")
+func addManagedDir(addr string, useTLS bool, path string) (managedDirResponse, error) {
+	url := addrToURL(addr, "/api/dirs", useTLS)
 	body, err := json.Marshal(map[string]any{"path": path})
 	if err != nil {
 		return managedDirResponse{}, err
@@ -462,7 +492,7 @@ func addManagedDir(addr, path string) (managedDirResponse, error) {
 		return managedDirResponse{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: 3 * time.Second}
+	client := newHTTPClient(useTLS, 3*time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return managedDirResponse{}, err
@@ -482,13 +512,13 @@ func addManagedDir(addr, path string) (managedDirResponse, error) {
 	return managedDirResponse{}, fmt.Errorf("failed to add managed directory: %s", message)
 }
 
-func removeManagedDir(addr, path string) error {
-	endpoint := addrToURL(addr, "/api/dirs?path="+url.QueryEscape(path))
+func removeManagedDir(addr string, useTLS bool, path string) error {
+	endpoint := addrToURL(addr, "/api/dirs?path="+url.QueryEscape(path), useTLS)
 	req, err := http.NewRequest(http.MethodDelete, endpoint, nil)
 	if err != nil {
 		return err
 	}
-	client := &http.Client{Timeout: 3 * time.Second}
+	client := newHTTPClient(useTLS, 3*time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -520,16 +550,16 @@ func removeManagedDirFromRegistry(path string) error {
 	return app.RemoveManagedDirFromRegistry(path)
 }
 
-func handleRemoveRoot(addr, path string) error {
-	if serverRunning(addr) {
-		return removeManagedDir(addr, path)
+func handleRemoveRoot(addr string, useTLS bool, path string) error {
+	if serverRunning(addr, useTLS) {
+		return removeManagedDir(addr, useTLS, path)
 	}
 	return removeManagedDirFromRegistry(path)
 }
 
-func fetchRelayStatus(addr string) (relayStatusResponse, error) {
-	url := addrToURL(addr, "/api/relay/status")
-	client := &http.Client{Timeout: 3 * time.Second}
+func fetchRelayStatus(addr string, useTLS bool) (relayStatusResponse, error) {
+	url := addrToURL(addr, "/api/relay/status", useTLS)
+	client := newHTTPClient(useTLS, 3*time.Second)
 	resp, err := client.Get(url)
 	if err != nil {
 		return relayStatusResponse{}, err
@@ -550,8 +580,8 @@ func fetchRelayStatus(addr string) (relayStatusResponse, error) {
 	return out, nil
 }
 
-func openTarget(addr string, rootID string) error {
-	status, err := fetchRelayStatus(addr)
+func openTarget(addr string, useTLS bool, rootID string) error {
+	status, err := fetchRelayStatus(addr, useTLS)
 	if err != nil {
 		return err
 	}
@@ -568,7 +598,7 @@ func openTarget(addr string, rootID string) error {
 		}
 		target = u.String()
 	} else {
-		target = localOpenURL(addr, rootID)
+		target = localOpenURL(addr, useTLS, rootID)
 	}
 	return openBrowser(target)
 }
@@ -584,8 +614,8 @@ func reportOpenTargetError(w io.Writer, err error) {
 	fmt.Fprintln(w, err.Error())
 }
 
-func localOpenURL(addr string, rootID string) string {
-	base := addrToURL(addr, "")
+func localOpenURL(addr string, useTLS bool, rootID string) string {
+	base := addrToURL(addr, "", useTLS)
 	u, err := url.Parse(base)
 	if err != nil {
 		return base
@@ -617,7 +647,7 @@ func openBrowser(target string) error {
 	return cmd.Start()
 }
 
-func addrToURL(addr, path string) string {
+func addrToURL(addr, path string, useTLS bool) string {
 	if strings.HasPrefix(addr, "http://") || strings.HasPrefix(addr, "https://") {
 		return addr + path
 	}
@@ -629,16 +659,23 @@ func addrToURL(addr, path string) string {
 	if host == "" {
 		host = "localhost"
 	}
+	if host == "0.0.0.0" {
+		host = "127.0.0.1"
+	}
 	if port == "" {
 		port = "7331"
 	}
-	return fmt.Sprintf("http://%s:%s%s", host, port, path)
+	scheme := "http"
+	if useTLS {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://%s:%s%s", scheme, host, port, path)
 }
 
-func waitForServer(addr string, timeout time.Duration) error {
+func waitForServer(addr string, useTLS bool, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if serverRunning(addr) {
+		if serverRunning(addr, useTLS) {
 			return nil
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/server/app/server.go
+++ b/server/app/server.go
@@ -15,6 +15,7 @@ import (
 	"mindfs/server/internal/githubimport"
 	"mindfs/server/internal/preferences"
 	"mindfs/server/internal/relay"
+	"mindfs/server/internal/tlsutil"
 	"mindfs/server/internal/update"
 )
 
@@ -24,6 +25,9 @@ type StartOptions struct {
 	Version      string
 	Args         []string
 	E2EEConfig   E2EEConfig
+	UseTLS       bool
+	CertFile     string
+	KeyFile      string
 }
 
 type E2EEConfig struct {
@@ -116,7 +120,7 @@ func Start(ctx context.Context, addr string, opts StartOptions) error {
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
-	relayMgr, err := relay.NewManager(addr, opts.NoRelayer, relayBaseURL)
+	relayMgr, err := relay.NewManager(addr, opts.NoRelayer, relayBaseURL, opts.UseTLS)
 	if err != nil {
 		return err
 	}
@@ -138,6 +142,9 @@ func Start(ctx context.Context, addr string, opts StartOptions) error {
 		services.E2EE.StartCleanup(ctx.Done())
 	}
 
+	if opts.UseTLS {
+		return server.ListenAndServeTLS(opts.CertFile, opts.KeyFile)
+	}
 	return server.ListenAndServe()
 }
 
@@ -162,4 +169,11 @@ func RemoveManagedDirFromRegistry(path string) error {
 	}
 	_, err = registry.Remove(path)
 	return err
+}
+
+// EnsureTLSCert resolves TLS certificate and key file paths for the server.
+// When certFlag or keyFlag are empty, a self-signed certificate is generated
+// under os.UserConfigDir/mindfs/ and reused across restarts.
+func EnsureTLSCert(certFlag, keyFlag string) (string, string, error) {
+	return tlsutil.EnsureCert(certFlag, keyFlag)
 }

--- a/server/internal/relay/manager.go
+++ b/server/internal/relay/manager.go
@@ -42,8 +42,8 @@ type Manager struct {
 	lastError    string
 }
 
-func NewManager(localAddr string, noRelayer bool, relayBaseURL string) (*Manager, error) {
-	service, err := NewService(localAddr)
+func NewManager(localAddr string, noRelayer bool, relayBaseURL string, useTLS bool) (*Manager, error) {
+	service, err := NewService(localAddr, useTLS)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/relay/service.go
+++ b/server/internal/relay/service.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,6 +35,7 @@ type Service struct {
 	localURL  string
 	store     *CredentialsStore
 	client    *http.Client
+	useTLS    bool
 }
 
 type credentialResponse struct {
@@ -54,7 +56,7 @@ type BindPollResult struct {
 	Credentials   RelayCredentials
 }
 
-func NewService(localAddr string) (*Service, error) {
+func NewService(localAddr string, useTLS bool) (*Service, error) {
 	store, err := NewCredentialsStore()
 	if err != nil {
 		return nil, err
@@ -62,15 +64,31 @@ func NewService(localAddr string) (*Service, error) {
 	if _, err := getOrCreateDeviceID(); err != nil {
 		return nil, err
 	}
-	return &Service{
-		localAddr: localAddr,
-		localURL:  addrToURL(localAddr, ""),
-		store:     store,
+
+	var client *http.Client
+	if useTLS {
+		// InsecureSkipVerify is used because the relay connects to the local
+		// MindFS server (loopback or same machine), which may present a
+		// self-signed certificate. No traffic leaves the host.
+		client = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+	} else {
 		// Do not apply a whole-request timeout here. Relay traffic can include
 		// large static assets and streamed responses; http.Client.Timeout would
 		// abort the body read mid-transfer and surface as a 502 on the relayed
 		// path even when the local server is healthy.
-		client: &http.Client{},
+		client = &http.Client{}
+	}
+
+	return &Service{
+		localAddr: localAddr,
+		localURL:  addrToURL(localAddr, "", useTLS),
+		store:     store,
+		client:    client,
+		useTLS:    useTLS,
 	}, nil
 }
 
@@ -287,6 +305,12 @@ func (s *Service) proxyWebSocket(req *http.Request, stream io.ReadWriter) error 
 	headers.Del("Sec-WebSocket-Extensions")
 
 	dialer := *websocket.DefaultDialer
+	if s.useTLS {
+		// InsecureSkipVerify is used because the relay connects to the local
+		// MindFS server (loopback or same machine), which may present a
+		// self-signed certificate. No traffic leaves the host.
+		dialer.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 	if protocol := strings.TrimSpace(req.Header.Get("Sec-WebSocket-Protocol")); protocol != "" {
 		dialer.Subprotocols = splitHeaderValues(protocol)
 	}
@@ -339,7 +363,7 @@ func (s *Service) waitForLocalServer(ctx context.Context) error {
 	}
 }
 
-func addrToURL(addr, path string) string {
+func addrToURL(addr, path string, useTLS bool) string {
 	if strings.HasPrefix(addr, "http://") || strings.HasPrefix(addr, "https://") {
 		return strings.TrimSuffix(addr, "/") + path
 	}
@@ -351,10 +375,17 @@ func addrToURL(addr, path string) string {
 	if host == "" {
 		host = "localhost"
 	}
+	if host == "0.0.0.0" {
+		host = "127.0.0.1"
+	}
 	if port == "" {
 		port = "7331"
 	}
-	return fmt.Sprintf("http://%s:%s%s", host, port, path)
+	scheme := "http"
+	if useTLS {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://%s:%s%s", scheme, host, port, path)
 }
 
 func localTargetURL(base string, requestURL *url.URL) (*url.URL, error) {

--- a/server/internal/relay/service_test.go
+++ b/server/internal/relay/service_test.go
@@ -113,7 +113,7 @@ func TestServicePollBind(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", configRoot)
 	t.Setenv("HOME", configRoot)
 
-	svc, err := NewService(":7331")
+	svc, err := NewService(":7331", false)
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
@@ -151,7 +151,7 @@ func TestManagerStartGeneratesPendingCode(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", configRoot)
 	t.Setenv("HOME", configRoot)
 
-	manager, err := NewManager(":7331", false, "https://relay.example.com")
+	manager, err := NewManager(":7331", false, "https://relay.example.com", false)
 	if err != nil {
 		t.Fatalf("NewManager() error = %v", err)
 	}
@@ -180,7 +180,7 @@ func TestManagerNoRelayerDoesNotGeneratePendingCode(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", configRoot)
 	t.Setenv("HOME", configRoot)
 
-	manager, err := NewManager(":7331", true, "https://relay.example.com")
+	manager, err := NewManager(":7331", true, "https://relay.example.com", false)
 	if err != nil {
 		t.Fatalf("NewManager() error = %v", err)
 	}
@@ -203,7 +203,7 @@ func TestManagerPollConfirmedStartsRelay(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", configRoot)
 	t.Setenv("HOME", configRoot)
 
-	manager, err := NewManager(":7331", false, "https://relay.example.com")
+	manager, err := NewManager(":7331", false, "https://relay.example.com", false)
 	if err != nil {
 		t.Fatalf("NewManager() error = %v", err)
 	}
@@ -264,7 +264,7 @@ func TestManagerPollTerminalBindStatusRefreshesPendingCode(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", configRoot)
 	t.Setenv("HOME", configRoot)
 
-	manager, err := NewManager(":7331", false, "https://relay.example.com")
+	manager, err := NewManager(":7331", false, "https://relay.example.com", false)
 	if err != nil {
 		t.Fatalf("NewManager() error = %v", err)
 	}
@@ -321,7 +321,7 @@ func TestManagerDefaultsRelayBaseToLocalhost(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", configRoot)
 	t.Setenv("HOME", configRoot)
 
-	manager, err := NewManager(":7331", false, "")
+	manager, err := NewManager(":7331", false, "", false)
 	if err != nil {
 		t.Fatalf("NewManager() error = %v", err)
 	}
@@ -344,7 +344,7 @@ func TestManagerPermanentRelayErrorClearsCredentialsAndRebinds(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", configRoot)
 	t.Setenv("HOME", configRoot)
 
-	manager, err := NewManager(":7331", false, "https://relay.example.com")
+	manager, err := NewManager(":7331", false, "https://relay.example.com", false)
 	if err != nil {
 		t.Fatalf("NewManager() error = %v", err)
 	}
@@ -412,7 +412,7 @@ func TestManagerStartClearsCredentialsWhenRelayBaseChanges(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", configRoot)
 	t.Setenv("HOME", configRoot)
 
-	manager, err := NewManager(":7331", false, "https://relay-new.example.com")
+	manager, err := NewManager(":7331", false, "https://relay-new.example.com", false)
 	if err != nil {
 		t.Fatalf("NewManager() error = %v", err)
 	}

--- a/server/internal/tlsutil/cert.go
+++ b/server/internal/tlsutil/cert.go
@@ -1,0 +1,158 @@
+// Package tlsutil provides utilities for TLS certificate management,
+// specifically self-signed certificate generation for local development.
+package tlsutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// EnsureCert resolves TLS certificate and key file paths.
+// If certFile and keyFile are both non-empty, they are used as-is
+// (caller must ensure they exist).
+// Otherwise, a self-signed certificate is generated under
+// os.UserConfigDir/mindfs/ and reused across restarts.
+func EnsureCert(certFile, keyFile string) (string, string, error) {
+	if certFile != "" && keyFile != "" {
+		return certFile, keyFile, nil
+	}
+
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", "", fmt.Errorf("cannot determine user config dir: %w", err)
+	}
+	certPath := filepath.Join(configDir, "mindfs", "cert.pem")
+	keyPath := filepath.Join(configDir, "mindfs", "key.pem")
+
+	_, certErr := os.Stat(certPath)
+	_, keyErr := os.Stat(keyPath)
+	if certErr == nil && keyErr == nil {
+		return certPath, keyPath, nil
+	}
+
+	if err := GenerateCert(certPath, keyPath); err != nil {
+		return "", "", fmt.Errorf("failed to generate self-signed certificate: %w", err)
+	}
+	return certPath, keyPath, nil
+}
+
+// GenerateCert creates a self-signed ECDSA P-256 certificate and key,
+// writing them atomically to certPath and keyPath. The certificate includes
+// SANs for localhost, 127.0.0.1, ::1, and all non-loopback, non-link-local
+// interface IPs so that LAN clients don't see certificate name mismatches.
+func GenerateCert(certPath, keyPath string) error {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return err
+	}
+
+	ips, err := collectInterfaceIPs()
+	if err != nil {
+		return err
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return err
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(10 * 365 * 24 * time.Hour)
+
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "mindfs-local",
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+		DNSNames:  []string{"localhost"},
+		IPAddresses: ips,
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(certPath), 0o755); err != nil {
+		return err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyBytes, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+
+	if err := atomicWrite(certPath, certPEM, 0o644); err != nil {
+		return err
+	}
+	return atomicWrite(keyPath, keyPEM, 0o600)
+}
+
+func collectInterfaceIPs() ([]net.IP, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	ips := []net.IP{
+		net.ParseIP("127.0.0.1"),
+		net.ParseIP("::1"),
+	}
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			ip := ipNet.IP
+			if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+				continue
+			}
+			ips = append(ips, ip)
+		}
+	}
+	return ips, nil
+}
+
+func atomicWrite(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, ".tmpcert-*")
+	if err != nil {
+		return err
+	}
+	tmpName := f.Name()
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := f.Chmod(perm); err != nil {
+		f.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, path)
+}


### PR DESCRIPTION
## Summary

- Add `-tls` CLI flag (default false) to enable HTTPS for the MindFS server
- Add `-cert` and `-key` flags for custom TLS certificate/key paths
- Auto-generate self-signed ECDSA P-256 certificate when `-tls` is used without custom certs
- Generated certificate includes SANs for localhost, 127.0.0.1, ::1, and all non-loopback interface IPs
- Certificates are stored under `os.UserConfigDir/mindfs/` and reused across restarts
- Relay module uses HTTPS when TLS is enabled, with `InsecureSkipVerify` for self-signed certs (internal local connections only)
- HTTP mode behavior is completely unchanged when `-tls` is not set
- Update README.md and README.zh.md with HTTPS usage documentation

## Files changed

- `cli/cmd/mindfs.go` — TLS flags, scheme switching, TLS-aware HTTP client for health checks
- `server/app/server.go` — StartOptions TLS fields, `ListenAndServeTLS`, `EnsureTLSCert`
- `server/internal/tlsutil/cert.go` — new package for self-signed cert generation
- `server/internal/relay/manager.go` — pass `useTLS` through to service
- `server/internal/relay/service.go` — HTTPS relay connections with `InsecureSkipVerify`
- `README.md` / `README.zh.md` — documentation updates