### PR TITLE
Fix Windows static asset path resolution

### DIFF
--- a/server/app/server.go
+++ b/server/app/server.go
@@ -158,21 +158,33 @@ func resolveStaticDir() string {
 		}
 	}
 
-	if shouldPreferWorkingDirStaticDir() {
-		if exe, err := os.Executable(); err == nil {
-			candidate := filepath.Join(filepath.Dir(exe), "web", "dist")
-			if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-				return candidate
-			}
-		}
-	}
-
 	if exe, err := os.Executable(); err == nil {
-		prefix := filepath.Dir(filepath.Dir(exe))
-		candidate := filepath.Join(prefix, "share", "mindfs", "web")
+		return resolveStaticDirFromExecutable(exe, shouldPreferWorkingDirStaticDir())
+	}
+	return ""
+}
+
+func resolveStaticDirFromExecutable(exe string, preferWorkingDir bool) string {
+	exe = strings.TrimSpace(exe)
+	if exe == "" {
+		return ""
+	}
+	exeDir := filepath.Dir(exe)
+	if preferWorkingDir {
+		candidate := filepath.Join(exeDir, "web", "dist")
 		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
 			return candidate
 		}
+	}
+	// 发布 zip 解压后，web 目录和可执行文件在同一层级。
+	candidate := filepath.Join(exeDir, "web")
+	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+		return candidate
+	}
+	// 安装布局为 <prefix>/bin/mindfs + <prefix>/share/mindfs/web。
+	candidate = filepath.Join(filepath.Dir(exeDir), "share", "mindfs", "web")
+	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+		return candidate
 	}
 	return ""
 }

--- a/server/app/server_test.go
+++ b/server/app/server_test.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveStaticDirFromExecutablePrefersReleaseArchiveLayout(t *testing.T) {
+	root := t.TempDir()
+	exeDir := filepath.Join(root, "bin")
+	releaseWeb := filepath.Join(exeDir, "web")
+	installedWeb := filepath.Join(root, "share", "mindfs", "web")
+	mkdirAll(t, releaseWeb)
+	mkdirAll(t, installedWeb)
+
+	got := resolveStaticDirFromExecutable(filepath.Join(exeDir, "mindfs.exe"), false)
+	if got != releaseWeb {
+		t.Fatalf("resolveStaticDirFromExecutable() = %q, want %q", got, releaseWeb)
+	}
+}
+
+func TestResolveStaticDirFromExecutableFallsBackToInstalledLayout(t *testing.T) {
+	root := t.TempDir()
+	exeDir := filepath.Join(root, "bin")
+	installedWeb := filepath.Join(root, "share", "mindfs", "web")
+	mkdirAll(t, installedWeb)
+
+	got := resolveStaticDirFromExecutable(filepath.Join(exeDir, "mindfs.exe"), false)
+	if got != installedWeb {
+		t.Fatalf("resolveStaticDirFromExecutable() = %q, want %q", got, installedWeb)
+	}
+}
+
+func mkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}

--- a/server/internal/api/http.go
+++ b/server/internal/api/http.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	stdpath "path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -1016,7 +1017,9 @@ func serveRewrittenStaticAsset(w http.ResponseWriter, r *http.Request, assetPath
 }
 
 func pathForStaticAsset(requestPath string) string {
-	cleaned := filepath.Clean("/" + requestPath)
+	// requestPath 是 URL path，分隔符固定为正斜杠。这里不能用 filepath，
+	// 否则 Windows 会把前导 // 当成 UNC 路径，最终泄漏成 web/// 这类路径。
+	cleaned := stdpath.Clean("/" + requestPath)
 	if cleaned == "/" {
 		return ""
 	}

--- a/server/internal/api/http_test.go
+++ b/server/internal/api/http_test.go
@@ -1,0 +1,36 @@
+package api
+
+import "testing"
+
+func TestPathForStaticAssetCleansURLPaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		requestPath string
+		want        string
+	}{
+		{
+			name:        "absolute asset path",
+			requestPath: "/assets/app.js",
+			want:        "assets/app.js",
+		},
+		{
+			name:        "duplicate slash path",
+			requestPath: "//assets/app.js",
+			want:        "assets/app.js",
+		},
+		{
+			name:        "root path",
+			requestPath: "/",
+			want:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pathForStaticAsset(tt.requestPath)
+			if got != tt.want {
+				t.Fatalf("pathForStaticAsset(%q) = %q, want %q", tt.requestPath, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Use URL path cleaning for static asset request paths so Windows does not treat leading `//` as a UNC-style path.
- Resolve release archive layouts where `web/` sits next to the `mindfs` executable, while preserving the installed `<prefix>/share/mindfs/web` layout.
- Add regression tests for URL asset path cleaning and static directory resolution.

## Verification
- `go test -count=1 ./server/app ./server/internal/api` passes.
- `go test ./...` currently fails on the existing upstream baseline before this change: `server/internal/agent/pool_test.go` has a syntax error near `TestDefaultConfigIncludesOMPAgent`, and environment-dependent usecase/relay tests also fail locally.