### PR TITLE
fix(web): truncate git branch label

### DIFF
--- a/web/src/components/GitStatusPanel.tsx
+++ b/web/src/components/GitStatusPanel.tsx
@@ -302,8 +302,20 @@ export function GitStatusPanel({
   return (
     <section style={{ padding: 0, flexShrink: 0, minWidth: 0 }}>
       {showHeader ? (
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: compact ? "6px" : "12px", marginBottom: headerMarginBottom, padding: compact ? "0 4px 0 0" : "0 10px", minWidth: 0 }}>
-        <div style={{ display: "flex", alignItems: "center", gap: "8px", minWidth: 0 }}>
+      <div
+        className="mindfs-git-status-header"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "minmax(0, 1fr) auto",
+          alignItems: "center",
+          gap: compact ? "6px" : "12px",
+          marginBottom: headerMarginBottom,
+          padding: compact ? "0 4px 0 0" : "0 10px",
+          minWidth: 0,
+          width: "100%",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: compact ? "6px" : "8px", minWidth: 0, overflow: "visible" }}>
           <span
             title="Git 变更"
             aria-label="Git 变更"
@@ -325,9 +337,16 @@ export function GitStatusPanel({
             </svg>
           </span>
           {status?.branch ? (
-            <div ref={branchMenuRef} style={{ position: "relative", minWidth: 0 }}>
+            <div
+              ref={branchMenuRef}
+              className={compact ? "mindfs-git-branch-wrap mindfs-git-branch-wrap-compact" : "mindfs-git-branch-wrap"}
+              data-branch-tooltip={branchMenuOpen ? undefined : status.branch}
+              style={{ position: "relative", minWidth: 0, flex: "1 1 auto", maxWidth: "100%" }}
+            >
               <button
                 type="button"
+                className="mindfs-git-branch-button"
+                aria-label={`当前分支：${status.branch}`}
                 onClick={() => {
                   if (enableBranchMenu && rootId && onSwitchBranch) {
                     setBranchMenuOpen((open) => !open);
@@ -343,12 +362,11 @@ export function GitStatusPanel({
                   display: "inline-flex",
                   alignItems: "center",
                   gap: "4px",
-                  minWidth: 0,
-                  maxWidth: "180px",
+                  width: "100%",
                   cursor: enableBranchMenu && rootId && onSwitchBranch ? "pointer" : "default",
                 }}
               >
-                <span style={{ fontSize: "12px", fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                <span className="mindfs-git-branch-label" style={{ fontSize: "12px", fontWeight: 600 }}>
                   {status.branch}
                 </span>
                 {enableBranchMenu && onSwitchBranch ? (
@@ -402,6 +420,7 @@ export function GitStatusPanel({
                       <button
                         key={branch.name}
                         type="button"
+                        title={branch.name}
                         disabled={active || !!switchingBranch}
                         onClick={async () => {
                           setSwitchingBranch(branch.name);
@@ -443,7 +462,7 @@ export function GitStatusPanel({
             </div>
           ) : null}
         </div>
-        <div style={{ display: "flex", alignItems: "center", gap: "1px", flexShrink: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "1px", flex: "0 0 auto", minWidth: "fit-content" }}>
           {showHeaderActions ? (
             <>
               <GitIconButton

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -84,6 +84,83 @@
   }
 }
 
+.mindfs-git-status-header {
+  overflow: visible;
+}
+
+.mindfs-git-branch-wrap {
+  width: min(180px, 100%);
+}
+
+.mindfs-git-branch-wrap[data-branch-tooltip]:hover::after,
+.mindfs-git-branch-wrap[data-branch-tooltip]:focus-within::after {
+  content: attr(data-branch-tooltip);
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 80;
+  box-sizing: border-box;
+  width: max-content;
+  max-width: min(320px, calc(100vw - 32px));
+  padding: 6px 8px;
+  border: 1px solid var(--menu-border);
+  border-radius: 7px;
+  background: var(--menu-bg);
+  color: var(--text-primary);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.18);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  pointer-events: none;
+  white-space: normal;
+}
+
+.mindfs-git-branch-wrap[data-branch-tooltip]:hover::before,
+.mindfs-git-branch-wrap[data-branch-tooltip]:focus-within::before {
+  content: "";
+  position: absolute;
+  top: calc(100% + 3px);
+  left: 14px;
+  z-index: 81;
+  width: 8px;
+  height: 8px;
+  border-left: 1px solid var(--menu-border);
+  border-top: 1px solid var(--menu-border);
+  background: var(--menu-bg);
+  pointer-events: none;
+  transform: rotate(45deg);
+}
+
+.mindfs-git-branch-wrap-compact {
+  width: min(112px, 100%);
+}
+
+.mindfs-git-branch-button {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.mindfs-git-branch-label {
+  min-width: 0;
+  flex: 1 1 auto;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 767px) {
+  .mindfs-git-branch-wrap {
+    width: min(34vw, 136px, 100%);
+  }
+
+  .mindfs-git-branch-wrap-compact {
+    width: min(28vw, 96px, 100%);
+  }
+}
+
 html {
   height: 100%;
   height: var(--mindfs-viewport-height, 100dvh);


### PR DESCRIPTION
## Summary
- constrain the Git status header so long branch names cannot cover pull/push/commit actions
- truncate long branch labels and show the full branch name in an adaptive tooltip
- add compact mobile sizing for the branch label area

## Tests
- npm run typecheck
