### PR TITLE
feat(codex): 支持隐藏模型及思考等级透传；拆分 Agent/Model 选择器

### DIFF
--- a/server/internal/agent/codex/session.go
+++ b/server/internal/agent/codex/session.go
@@ -690,7 +690,8 @@ func (s *session) ListModels(ctx context.Context) (types.ModelList, error) {
 	if s == nil || s.client == nil {
 		return types.ModelList{}, errors.New("codex session not initialized")
 	}
-	resp, err := s.client.ListModels(ctx, codexsdk.ModelListParams{})
+	includeHidden := true
+	resp, err := s.client.ListModels(ctx, codexsdk.ModelListParams{IncludeHidden: &includeHidden})
 	if err != nil {
 		return types.ModelList{}, err
 	}
@@ -698,17 +699,7 @@ func (s *session) ListModels(ctx context.Context) (types.ModelList, error) {
 	currentModelID := ""
 	defaults, _ := s.RuntimeDefaults(ctx)
 	for _, model := range resp.Data {
-		name := strings.TrimSpace(model.DisplayName)
-		if name == "" {
-			name = strings.TrimSpace(model.Model)
-		}
-		models = append(models, types.ModelInfo{
-			ID:            model.Model,
-			Name:          name,
-			Description:   model.Description,
-			Hidden:        model.Hidden,
-			SupportEffort: true,
-		})
+		models = append(models, mapCodexModel(model))
 		if model.IsDefault && currentModelID == "" {
 			currentModelID = model.Model
 		}
@@ -720,6 +711,39 @@ func (s *session) ListModels(ctx context.Context) (types.ModelList, error) {
 		CurrentModelID: currentModelID,
 		Models:         models,
 	}, nil
+}
+
+func mapCodexModel(model codexsdk.Model) types.ModelInfo {
+	name := strings.TrimSpace(model.DisplayName)
+	if name == "" {
+		name = strings.TrimSpace(model.Model)
+	}
+
+	// app-server 已按模型返回完整能力；原样保序透传，兼容 max、ultra 及未来新增等级。
+	efforts := make([]string, 0, len(model.SupportedReasoningEfforts))
+	seen := make(map[string]struct{}, len(model.SupportedReasoningEfforts))
+	for _, option := range model.SupportedReasoningEfforts {
+		effort := strings.ToLower(strings.TrimSpace(string(option.ReasoningEffort)))
+		if effort == "" {
+			continue
+		}
+		if _, ok := seen[effort]; ok {
+			continue
+		}
+		seen[effort] = struct{}{}
+		efforts = append(efforts, effort)
+	}
+
+	return types.ModelInfo{
+		ID:          model.Model,
+		Name:        name,
+		Description: model.Description,
+		Hidden:      model.Hidden,
+		// 旧版 app-server 省略该字段时沿用原有能力回退；显式空数组则表示模型不支持。
+		SupportEffort: model.SupportedReasoningEfforts == nil || len(efforts) > 0,
+		Efforts:       efforts,
+		DefaultEffort: strings.ToLower(strings.TrimSpace(string(model.DefaultReasoningEffort))),
+	}
 }
 
 func (s *session) RuntimeDefaults(ctx context.Context) (types.RuntimeDefaults, error) {

--- a/server/internal/agent/codex/session_test.go
+++ b/server/internal/agent/codex/session_test.go
@@ -1,7 +1,9 @@
 package codex
 
 import (
+	"context"
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	agenttypes "mindfs/server/internal/agent/types"
@@ -9,6 +11,66 @@ import (
 	codexsdk "github.com/fanwenlin/codex-go-sdk/codex"
 	codextypes "github.com/fanwenlin/codex-go-sdk/types"
 )
+
+type modelListExecStub struct {
+	params   codextypes.ModelListParams
+	response *codextypes.ModelListResponse
+}
+
+func (e *modelListExecStub) Run(codexsdk.CodexExecArgs) <-chan codexsdk.ExecResult {
+	output := make(chan codexsdk.ExecResult)
+	close(output)
+	return output
+}
+
+func (e *modelListExecStub) ListModels(_ context.Context, params codextypes.ModelListParams) (*codextypes.ModelListResponse, error) {
+	e.params = params
+	return e.response, nil
+}
+
+func (e *modelListExecStub) RPCCall(_ context.Context, _ string, _ interface{}) (json.RawMessage, error) {
+	return json.RawMessage(`{"config":{}}`), nil
+}
+
+func TestListModelsPreservesPerModelReasoningEfforts(t *testing.T) {
+	effortOptions := []codextypes.ReasoningEffortOption{
+		{ReasoningEffort: codextypes.ReasoningEffort("low")},
+		{ReasoningEffort: codextypes.ReasoningEffort("medium")},
+		{ReasoningEffort: codextypes.ReasoningEffort("high")},
+		{ReasoningEffort: codextypes.ReasoningEffort("xhigh")},
+		{ReasoningEffort: codextypes.ReasoningEffort("max")},
+		{ReasoningEffort: codextypes.ReasoningEffort("ultra")},
+	}
+	exec := &modelListExecStub{response: &codextypes.ModelListResponse{
+		Data: []codextypes.Model{{
+			Model:                     "gpt-5.6-sol",
+			DisplayName:               "GPT-5.6-Sol",
+			SupportedReasoningEfforts: effortOptions,
+			DefaultReasoningEffort:    codextypes.ReasoningEffort("low"),
+			IsDefault:                 true,
+		}},
+	}}
+	s := &session{client: codexsdk.NewCodexWithExec(exec, codextypes.CodexOptions{})}
+
+	models, err := s.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if exec.params.IncludeHidden == nil || !*exec.params.IncludeHidden {
+		t.Fatal("ListModels() did not request hidden models")
+	}
+	if len(models.Models) != 1 {
+		t.Fatalf("models count = %d, want 1", len(models.Models))
+	}
+	got := models.Models[0]
+	wantEfforts := []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+	if !reflect.DeepEqual(got.Efforts, wantEfforts) {
+		t.Fatalf("efforts = %#v, want %#v", got.Efforts, wantEfforts)
+	}
+	if !got.SupportEffort || got.DefaultEffort != "low" {
+		t.Fatalf("model effort metadata = %#v", got)
+	}
+}
 
 func TestHandleRawEventPlanDeltaAggregatesPlanUpdates(t *testing.T) {
 	s := &session{}

--- a/server/internal/agent/probe.go
+++ b/server/internal/agent/probe.go
@@ -709,7 +709,9 @@ func statusChanged(prev Status, next Status) bool {
 			prev.Models[i].Name != next.Models[i].Name ||
 			prev.Models[i].Description != next.Models[i].Description ||
 			prev.Models[i].Hidden != next.Models[i].Hidden ||
-			prev.Models[i].SupportEffort != next.Models[i].SupportEffort {
+			prev.Models[i].SupportEffort != next.Models[i].SupportEffort ||
+			prev.Models[i].DefaultEffort != next.Models[i].DefaultEffort ||
+			!equalStrings(prev.Models[i].Efforts, next.Models[i].Efforts) {
 			return true
 		}
 	}
@@ -930,11 +932,25 @@ func preserveKnownCapabilities(prev Status, next Status) Status {
 func inferAgentEfforts(models []agenttypes.ModelInfo) []string {
 	hasSupport := false
 	looksLikeClaude := false
+	explicitEfforts := make([]string, 0)
+	seenEfforts := make(map[string]struct{})
 	for _, model := range models {
 		if !model.SupportEffort {
 			continue
 		}
 		hasSupport = true
+		// 新协议以模型目录为准；Agent 级列表仅作为旧前端和旧 Agent 的能力并集。
+		for _, rawEffort := range model.Efforts {
+			effort := strings.ToLower(strings.TrimSpace(rawEffort))
+			if effort == "" {
+				continue
+			}
+			if _, ok := seenEfforts[effort]; ok {
+				continue
+			}
+			seenEfforts[effort] = struct{}{}
+			explicitEfforts = append(explicitEfforts, effort)
+		}
 		joined := strings.ToLower(strings.TrimSpace(model.ID) + " " + strings.TrimSpace(model.Name))
 		if strings.Contains(joined, "sonnet") || strings.Contains(joined, "opus") {
 			looksLikeClaude = true
@@ -943,10 +959,25 @@ func inferAgentEfforts(models []agenttypes.ModelInfo) []string {
 	if !hasSupport {
 		return nil
 	}
+	if len(explicitEfforts) > 0 {
+		return explicitEfforts
+	}
 	if looksLikeClaude {
 		return []string{"low", "medium", "high", "xhigh", "max"}
 	}
 	return []string{"low", "medium", "high", "xhigh"}
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func supportsAgentFastService(agentName string) bool {

--- a/server/internal/agent/probe_test.go
+++ b/server/internal/agent/probe_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+
+	agenttypes "mindfs/server/internal/agent/types"
+)
+
+func TestInferAgentEffortsUsesModelCatalog(t *testing.T) {
+	models := []agenttypes.ModelInfo{
+		{
+			ID:            "gpt-5.6-sol",
+			SupportEffort: true,
+			Efforts:       []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+		},
+		{
+			ID:            "gpt-5.6-terra",
+			SupportEffort: true,
+			Efforts:       []string{"medium", "ultra"},
+		},
+	}
+
+	got := inferAgentEfforts(models)
+	want := []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("inferAgentEfforts() = %#v, want %#v", got, want)
+	}
+}
+
+func TestInferAgentEffortsKeepsLegacyFallback(t *testing.T) {
+	got := inferAgentEfforts([]agenttypes.ModelInfo{{
+		ID:            "legacy-codex",
+		SupportEffort: true,
+	}})
+	want := []string{"low", "medium", "high", "xhigh"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("inferAgentEfforts() = %#v, want %#v", got, want)
+	}
+}
+
+func TestStatusChangedDetectsModelEffortMetadata(t *testing.T) {
+	previous := Status{Models: []agenttypes.ModelInfo{{
+		ID:            "gpt-5.6-sol",
+		SupportEffort: true,
+		Efforts:       []string{"low", "medium"},
+		DefaultEffort: "low",
+	}}}
+	next := previous
+	next.Models = append([]agenttypes.ModelInfo(nil), previous.Models...)
+	next.Models[0].Efforts = []string{"low", "medium", "ultra"}
+
+	if !statusChanged(previous, next) {
+		t.Fatal("statusChanged() = false, want true for model effort changes")
+	}
+}

--- a/server/internal/agent/types/types.go
+++ b/server/internal/agent/types/types.go
@@ -193,6 +193,9 @@ type ModelInfo struct {
 	Description   string `json:"description,omitempty"`
 	Hidden        bool   `json:"hidden,omitempty"`
 	SupportEffort bool   `json:"supportEffort,omitempty"`
+	// Efforts 和 DefaultEffort 来自模型目录，避免把不同模型的思考等级混成 Agent 全局能力。
+	Efforts       []string `json:"efforts,omitempty"`
+	DefaultEffort string   `json:"default_effort,omitempty"`
 }
 
 type ModelList struct {

--- a/web/src/components/ActionBar.tsx
+++ b/web/src/components/ActionBar.tsx
@@ -3,6 +3,9 @@ import { type SessionMode } from "./ModeSelector";
 import { ModeSelector } from "./ModeSelector";
 import { AgentSelector } from "./AgentSelector";
 import { ModelSelector } from "./ModelSelector";
+import { AgentModeSelector } from "./AgentModeSelector";
+import { EffortSelector } from "./EffortSelector";
+import { FastServiceSelector } from "./FastServiceSelector";
 import { fetchAgents, fetchShells, restartAgent, type AgentStatus, type ShellStatus } from "../services/agents";
 import { fetchCandidates, type CandidateItem } from "../services/candidates";
 import { reportError } from "../services/error";
@@ -1588,9 +1591,6 @@ export function ActionBar({
                   <ModelSelector
                     agent={selectedAgent}
                     model={model}
-                    mode={agentMode}
-                    effort={effort}
-                    fastService={fastService}
                     compact
                     maxButtonWidth={isMobile ? "min(25vw, 88px)" : "132px"}
                     onModelChange={(nextModel) => {
@@ -1600,8 +1600,26 @@ export function ActionBar({
                       setEffort(getModelDefaultEffort(selectedAgent, nextModel));
                       setFastService(defaults.fastService);
                     }}
+                  />
+                  <AgentModeSelector
+                    agent={selectedAgent}
+                    mode={agentMode}
+                    compact
+                    maxButtonWidth={isMobile ? "min(25vw, 88px)" : "132px"}
                     onModeChange={(nextAgentMode) => setAgentMode(nextAgentMode || "")}
+                  />
+                  <EffortSelector
+                    agent={selectedAgent}
+                    model={model}
+                    effort={effort}
+                    compact
+                    maxButtonWidth={isMobile ? "min(25vw, 88px)" : "132px"}
                     onEffortChange={(nextEffort) => setEffort(nextEffort || "")}
+                  />
+                  <FastServiceSelector
+                    agent={selectedAgent}
+                    fastService={fastService}
+                    compact
                     onFastServiceChange={(nextFastService) => setFastService(nextFastService || "")}
                   />
                 </div>

--- a/web/src/components/ActionBar.tsx
+++ b/web/src/components/ActionBar.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { type SessionMode } from "./ModeSelector";
 import { ModeSelector } from "./ModeSelector";
 import { AgentSelector } from "./AgentSelector";
+import { ModelSelector } from "./ModelSelector";
 import { fetchAgents, fetchShells, restartAgent, type AgentStatus, type ShellStatus } from "../services/agents";
 import { fetchCandidates, type CandidateItem } from "../services/candidates";
 import { reportError } from "../services/error";
@@ -162,6 +163,15 @@ function getAgentDefaults(agent?: AgentStatus | null) {
     effort: agent?.default_effort || "",
     fastService: (agent?.default_fast_service || "") as "" | "on" | "off",
   } as const;
+}
+
+function getModelDefaultEffort(agent: AgentStatus | null | undefined, modelID: string): string {
+  const model = agent?.models?.find((item) => item.id === modelID);
+  if (model && !model.supportEffort) return "";
+  const modelEfforts = model?.efforts ?? [];
+  const availableEfforts = modelEfforts.length > 0 ? modelEfforts : agent?.efforts ?? [];
+  const candidates = [model?.default_effort || "", agent?.default_effort || ""];
+  return candidates.find((item) => item && availableEfforts.includes(item)) || availableEfforts[0] || "";
 }
 
 function buildPendingAttachment(file: File): PendingAttachment {
@@ -565,7 +575,11 @@ export function ActionBar({
     || (selectedAgent?.models ?? []).find(
       (item) => item.id === (selectedAgent?.default_model_id || selectedAgent?.current_model_id),
     );
-  const availableEfforts = selectedAgent?.efforts ?? [];
+  // 优先使用当前模型的能力，避免给 gpt-5.5 显示仅 gpt-5.6 支持的 ultra/max。
+  const modelEfforts = selectedModelInfo?.efforts ?? [];
+  const availableEfforts = modelEfforts.length > 0
+    ? modelEfforts
+    : selectedAgent?.efforts ?? [];
   const isCodexEffortAgent = selectedAgent?.name === "codex";
   const supportsEffort =
     availableEfforts.length > 0 && !!selectedModelInfo?.supportEffort;
@@ -582,9 +596,17 @@ export function ActionBar({
       return;
     }
     if (effort && !availableEfforts.includes(effort)) {
-      setEffort(getAgentDefaults(selectedAgent).effort);
+      const modelDefault = selectedModelInfo?.default_effort || "";
+      const agentDefault = getAgentDefaults(selectedAgent).effort;
+      setEffort(
+        availableEfforts.includes(modelDefault)
+          ? modelDefault
+          : availableEfforts.includes(agentDefault)
+            ? agentDefault
+            : availableEfforts[0] || "",
+      );
     }
-  }, [supportsEffort, effort, availableEfforts, selectedAgent, isCodexEffortAgent]);
+  }, [supportsEffort, effort, availableEfforts, selectedAgent, selectedModelInfo, isCodexEffortAgent]);
 
   useEffect(() => {
     if (!supportsServiceTier) {
@@ -1048,7 +1070,12 @@ export function ActionBar({
     : mode === "chat" && !isFocused
       ? blurPlaceholder
       : modePlaceholders[mode];
-  const editorRightInset = isMultiLine ? 14 : mode === "command" ? (isMobile ? 92 : 116) : isMobile ? 124 : 148;
+  // Agent 与模型拆成两个相邻控件后，单行编辑器需为右侧工具栏预留更多空间。
+  const editorRightInset = isMultiLine
+    ? 14
+    : mode === "command"
+      ? isMobile ? 92 : 116
+      : isMobile ? 224 : 280;
   const editorBottomInset = isMultiLine ? 44 : 12;
   const editorMinHeight = 44;
   const mobileFileSidebarButton = isMobile ? (
@@ -1537,26 +1564,19 @@ export function ActionBar({
 
               <ModeSelector mode={mode} onModeChange={setMode} compact={true} disabled={isModeLocked} />
               {mode !== "command" ? (
-                <div>
+                <div style={{ display: "flex", alignItems: "center", minWidth: 0 }}>
                   <AgentSelector
                     agent={agent}
-                    model={model}
-                    mode={agentMode}
-                    effort={effort}
                     agents={agents}
-                    onAgentChange={(nextAgent, nextModel) => {
+                    onAgentChange={(nextAgent) => {
                       const nextStatus = agents.find((item) => item.name === nextAgent);
                       const defaults = getAgentDefaults(nextStatus);
                       setAgent(nextAgent);
-                      setModel(nextModel || defaults.model);
+                      setModel(defaults.model);
                       setAgentMode("");
-                      setEffort(defaults.effort);
+                      setEffort(getModelDefaultEffort(nextStatus, defaults.model));
                       setFastService(defaults.fastService);
                     }}
-                    onModeChange={(nextAgentMode) => setAgentMode(nextAgentMode || "")}
-                    onEffortChange={(nextEffort) => setEffort(nextEffort || "")}
-                    fastService={fastService}
-                    onFastServiceChange={(nextFastService) => setFastService(nextFastService || "")}
                     onAgentRestart={async (targetAgent) => {
                       await restartAgent(targetAgent);
                       const items = await fetchAgents(true);
@@ -1564,6 +1584,25 @@ export function ActionBar({
                     }}
                     compact={true}
                     warnUnavailable={isSelectedAgentUnavailable}
+                  />
+                  <ModelSelector
+                    agent={selectedAgent}
+                    model={model}
+                    mode={agentMode}
+                    effort={effort}
+                    fastService={fastService}
+                    compact
+                    maxButtonWidth={isMobile ? "min(25vw, 88px)" : "132px"}
+                    onModelChange={(nextModel) => {
+                      const defaults = getAgentDefaults(selectedAgent);
+                      setModel(nextModel);
+                      setAgentMode("");
+                      setEffort(getModelDefaultEffort(selectedAgent, nextModel));
+                      setFastService(defaults.fastService);
+                    }}
+                    onModeChange={(nextAgentMode) => setAgentMode(nextAgentMode || "")}
+                    onEffortChange={(nextEffort) => setEffort(nextEffort || "")}
+                    onFastServiceChange={(nextFastService) => setFastService(nextFastService || "")}
                   />
                 </div>
               ) : (

--- a/web/src/components/AgentModeSelector.tsx
+++ b/web/src/components/AgentModeSelector.tsx
@@ -1,34 +1,31 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { AgentStatus } from "../services/agents";
 
-type ModelSelectorProps = {
+type AgentModeSelectorProps = {
   agent?: AgentStatus | null;
-  model?: string;
-  onModelChange: (model: string) => void;
+  mode?: string;
+  onModeChange?: (mode?: string) => void;
   compact?: boolean;
   menuPlacement?: "top" | "bottom";
   maxButtonWidth?: string;
 };
 
-/** 模型选择器：独立选择模型，不包含运行参数（模式/思考等级/Fast）。 */
-export function ModelSelector({
+/** Agent 模式选择器：独立选择运行模式，与模型/思考等级/Fast 配置解耦。 */
+export function AgentModeSelector({
   agent,
-  model = "",
-  onModelChange,
+  mode = "",
+  onModeChange,
   compact = false,
   menuPlacement = "top",
   maxButtonWidth = "min(30vw, 132px)",
-}: ModelSelectorProps) {
+}: AgentModeSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const models = agent?.models ?? [];
-  const selectedModel = useMemo(() => {
-    const fallback = agent?.default_model_id || agent?.current_model_id || "";
-    const target = model || fallback;
-    return models.find((item) => item.id === target) ?? null;
-  }, [agent, model, models]);
-  const displayName = selectedModel?.name || selectedModel?.id || model || "模型";
-  const hasModelContent = models.length > 0;
+  const modes = agent?.modes ?? [];
+  const displayedMode = mode || agent?.current_mode_id || "";
+  // 从 modes 中找到当前模式的 name 用于展示
+  const currentMode = modes.find((item) => item.id === displayedMode);
+  const displayName = currentMode?.name || currentMode?.id || displayedMode || "模式";
 
   useEffect(() => {
     if (!isOpen) return;
@@ -45,16 +42,15 @@ export function ModelSelector({
 
   const closeMenu = () => setIsOpen(false);
 
-  if (!agent && !model) return null;
+  if (modes.length === 0) return null;
 
   return (
     <div ref={dropdownRef} style={{ position: "relative", minWidth: 0 }}>
       <button
         type="button"
-        disabled={!hasModelContent || !agent?.available}
         onClick={() => setIsOpen((previous) => !previous)}
-        title={selectedModel?.description || selectedModel?.id || model || "当前 Agent 未提供模型"}
-        aria-label={`选择模型，当前为 ${displayName}`}
+        title={currentMode?.description || currentMode?.id || ""}
+        aria-label={`选择模式，当前为 ${displayName}`}
         style={{
           display: "inline-flex",
           alignItems: "center",
@@ -65,9 +61,8 @@ export function ModelSelector({
           border: "none",
           borderRadius: "10px",
           background: isOpen ? "rgba(59,130,246,0.08)" : "transparent",
-          color: agent?.available === false ? "var(--text-secondary)" : "var(--text-primary)",
-          cursor: hasModelContent && agent?.available !== false ? "pointer" : "default",
-          opacity: hasModelContent ? 1 : 0.58,
+          color: "var(--text-primary)",
+          cursor: "pointer",
           outline: "none",
         }}
       >
@@ -105,16 +100,16 @@ export function ModelSelector({
             zIndex: 1000,
           }}
         >
-          {models.map((item, index) => (
+          {modes.map((item, index) => (
             <button
               key={item.id}
               type="button"
               onClick={() => {
-                onModelChange(item.id);
+                onModeChange?.(item.id);
                 closeMenu();
               }}
               title={item.description || item.id}
-              style={sectionItemStyle(item.id === selectedModel?.id, index > 0, item.hidden ? 0.66 : 1)}
+              style={sectionItemStyle(item.id === displayedMode, index > 0)}
             >
               <span style={{ fontSize: "13px", fontWeight: 600 }}>{item.name || item.id}</span>
               {item.description ? <span style={descriptionStyle}>{item.description}</span> : null}
@@ -154,7 +149,7 @@ function SelectorChevron({ expanded }: { expanded: boolean }) {
   );
 }
 
-function sectionItemStyle(selected: boolean, topBorder = false, opacity = 1): React.CSSProperties {
+function sectionItemStyle(selected: boolean, topBorder = false): React.CSSProperties {
   return {
     display: "flex",
     flexDirection: "column",
@@ -169,6 +164,5 @@ function sectionItemStyle(selected: boolean, topBorder = false, opacity = 1): Re
     color: selected ? "#3b82f6" : "var(--text-primary)",
     textAlign: "left",
     cursor: "pointer",
-    opacity,
   };
 }

--- a/web/src/components/AgentSelector.tsx
+++ b/web/src/components/AgentSelector.tsx
@@ -1,24 +1,11 @@
-import React, {
-  useState,
-  useRef,
-  useEffect,
-  useCallback,
-  useMemo,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AgentIcon } from "./AgentIcon";
 import type { AgentStatus } from "../services/agents";
 
 type AgentSelectorProps = {
   agent: string;
-  model?: string;
-  mode?: string;
-  effort?: string;
-  fastService?: "" | "on" | "off";
   agents: AgentStatus[];
-  onAgentChange: (agent: string, model?: string) => void;
-  onModeChange?: (mode?: string) => void;
-  onEffortChange?: (effort?: string) => void;
-  onFastServiceChange?: (fastService?: "" | "on" | "off") => void;
+  onAgentChange: (agent: string) => void;
   onAgentRestart?: (agent: string) => void | Promise<void>;
   compact?: boolean;
   warnUnavailable?: boolean;
@@ -26,24 +13,11 @@ type AgentSelectorProps = {
   showChevron?: boolean;
 };
 
-const AGENT_MENU_MAX_BODY_HEIGHT = 344;
-const AGENT_MENU_HEADER_HEIGHT = 34;
-const AGENT_MENU_ROW_HEIGHT = 40;
-const AGENT_MENU_MIN_VISIBLE_ROWS = 3;
-const AGENT_MENU_MIN_BODY_HEIGHT =
-  AGENT_MENU_HEADER_HEIGHT +
-  AGENT_MENU_ROW_HEIGHT * AGENT_MENU_MIN_VISIBLE_ROWS;
-
 function parseAgentErrorMessage(error?: string): string {
   const raw = String(error || "").trim();
-  if (!raw) {
-    return "";
-  }
-
+  if (!raw) return "";
   try {
-    const parsed = JSON.parse(raw) as {
-      message?: unknown;
-    };
+    const parsed = JSON.parse(raw) as { message?: unknown };
     return typeof parsed.message === "string" && parsed.message.trim()
       ? parsed.message.trim()
       : raw;
@@ -54,71 +28,40 @@ function parseAgentErrorMessage(error?: string): string {
 
 function parseAgentErrorDetails(error?: string): string[] {
   const raw = String(error || "").trim();
-  if (!raw) {
-    return [];
-  }
-
+  if (!raw) return [];
   try {
-    const parsed = JSON.parse(raw) as {
-      data?: unknown;
-    };
-    if (parsed.data === undefined) {
-      return [];
-    }
-
+    const parsed = JSON.parse(raw) as { data?: unknown };
+    if (parsed.data === undefined) return [];
     if (Array.isArray(parsed.data)) {
       return parsed.data.map((item) => String(item)).filter(Boolean);
     }
-
     if (parsed.data && typeof parsed.data === "object") {
-      if (
-        Array.isArray((parsed.data as { authMethods?: unknown }).authMethods)
-      ) {
-        return (
-          parsed.data as {
-            authMethods: Array<{ name?: unknown; description?: unknown }>;
-          }
-        ).authMethods
+      const authMethods = (parsed.data as { authMethods?: unknown }).authMethods;
+      if (Array.isArray(authMethods)) {
+        return (authMethods as Array<{ name?: unknown; description?: unknown }>)
           .map((item) => {
             const name = typeof item?.name === "string" ? item.name.trim() : "";
             const description =
-              typeof item?.description === "string"
-                ? item.description.trim()
-                : "";
-            if (name && description) {
-              return `${name}: ${description}`;
-            }
-            return name || description;
+              typeof item?.description === "string" ? item.description.trim() : "";
+            return name && description ? `${name}: ${description}` : name || description;
           })
           .filter(Boolean);
       }
       return Object.entries(parsed.data as Record<string, unknown>).map(
-        ([key, value]) => {
-          if (typeof value === "string") {
-            return `${key}: ${value}`;
-          }
-          return `${key}: ${JSON.stringify(value)}`;
-        },
+        ([key, value]) => `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`,
       );
     }
-
     return [String(parsed.data)];
   } catch {
     return [];
   }
 }
 
+/** Agent 下拉只负责 Agent 本身；模型与运行参数由相邻的 ModelSelector 管理。 */
 export function AgentSelector({
   agent,
-  model = "",
-  mode = "",
-  effort = "",
-  fastService = "",
   agents,
   onAgentChange,
-  onModeChange,
-  onEffortChange,
-  onFastServiceChange,
   onAgentRestart,
   compact = false,
   warnUnavailable = false,
@@ -126,228 +69,43 @@ export function AgentSelector({
   showChevron = false,
 }: AgentSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [submenuAgent, setSubmenuAgent] = useState<string | null>(null);
   const [errorAgent, setErrorAgent] = useState<string | null>(null);
-  const [modelSectionExpanded, setModelSectionExpanded] = useState(true);
-  const [modeSectionExpanded, setModeSectionExpanded] = useState(false);
-  const [effortSectionExpanded, setEffortSectionExpanded] = useState(false);
-  const [serviceTierSectionExpanded, setServiceTierSectionExpanded] =
-    useState(false);
   const [restartingAgent, setRestartingAgent] = useState<string | null>(null);
-  const [menuBodyHeight, setMenuBodyHeight] = useState<number | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const agentColumnRef = useRef<HTMLDivElement>(null);
-  const submenuAgentStatus = useMemo(
-    () => agents.find((item) => item.name === submenuAgent) ?? null,
-    [agents, submenuAgent],
-  );
   const errorAgentStatus = useMemo(
     () => agents.find((item) => item.name === errorAgent) ?? null,
     [agents, errorAgent],
   );
-  const submenuModels = useMemo(
-    () => submenuAgentStatus?.models ?? [],
-    [submenuAgentStatus],
-  );
-  const submenuSelectedModel = useMemo(() => {
-    if (!submenuAgentStatus) return null;
-    const fallbackModel =
-      submenuAgentStatus.default_model_id ||
-      submenuAgentStatus.current_model_id ||
-      "";
-    const targetModel =
-      submenuAgentStatus.name === agent
-        ? model || fallbackModel
-        : fallbackModel;
-    return (
-      (submenuAgentStatus.models ?? []).find(
-        (item) => item.id === targetModel,
-      ) ?? null
-    );
-  }, [submenuAgentStatus, agent, model]);
-  const submenuEfforts = useMemo(
-    () => submenuAgentStatus?.efforts ?? [],
-    [submenuAgentStatus],
-  );
-  const submenuModes = useMemo(
-    () => submenuAgentStatus?.modes ?? [],
-    [submenuAgentStatus],
-  );
-  const displayedMode = useMemo(() => {
-    if (!submenuAgentStatus) return "";
-    const fallbackMode = submenuAgentStatus.current_mode_id || "";
-    return submenuAgentStatus.name === agent
-      ? mode || fallbackMode
-      : fallbackMode;
-  }, [submenuAgentStatus, agent, mode]);
-  const submenuIsCodex = submenuAgentStatus?.name === "codex";
-  const submenuSupportsEffort = useMemo(
-    () => submenuEfforts.length > 0 && !!submenuSelectedModel?.supportEffort,
-    [submenuEfforts, submenuSelectedModel],
-  );
-  const submenuSupportsServiceTier =
-    !!submenuAgentStatus?.supports_fast_service;
-  const fallbackEffort = submenuAgentStatus?.default_effort || "";
-  const displayedEffort = submenuIsCodex
-    ? effort || fallbackEffort || "Auto"
-    : effort || fallbackEffort || "Auto";
-  const fallbackFastService = submenuAgentStatus?.default_fast_service || "";
-  const fastModeEnabled =
-    (submenuAgentStatus?.name === agent ? fastService : fallbackFastService) ===
-    "on";
-  const buttonTitle = useMemo(() => {
-    if (warnUnavailable) {
-      return `当前会话的 Agent（${agent}）不可用`;
-    }
-    if (agent && model) {
-      return `${agent} · ${model}`;
-    }
-    return undefined;
-  }, [agent, model, warnUnavailable]);
 
   useEffect(() => {
-    const handlePointerOutside = (e: PointerEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(e.target as Node)
-      ) {
+    if (!isOpen) return;
+    const handlePointerOutside = (event: PointerEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false);
-        setSubmenuAgent(null);
         setErrorAgent(null);
-        setModelSectionExpanded(true);
-        setModeSectionExpanded(false);
-        setEffortSectionExpanded(false);
-        setServiceTierSectionExpanded(false);
-        setMenuBodyHeight(null);
       }
     };
-    if (isOpen) {
-      document.addEventListener("pointerdown", handlePointerOutside);
-      return () =>
-        document.removeEventListener("pointerdown", handlePointerOutside);
-    }
+    document.addEventListener("pointerdown", handlePointerOutside);
+    return () => document.removeEventListener("pointerdown", handlePointerOutside);
   }, [isOpen]);
 
-  useEffect(() => {
-    if (!isOpen || submenuAgent) {
-      return;
-    }
-    const node = agentColumnRef.current;
-    if (!node) {
-      return;
-    }
-    setMenuBodyHeight(
-      Math.min(
-        AGENT_MENU_MAX_BODY_HEIGHT,
-        Math.max(node.scrollHeight, AGENT_MENU_MIN_BODY_HEIGHT),
-      ),
-    );
-  }, [isOpen, submenuAgent, agents.length]);
-
   const handleAgentSelect = useCallback(
-    (newAgent: string, nextModel?: string) => {
-      onAgentChange(newAgent, nextModel);
+    (nextAgent: string) => {
+      onAgentChange(nextAgent);
       setIsOpen(false);
-      setSubmenuAgent(null);
       setErrorAgent(null);
-      setModelSectionExpanded(true);
-      setModeSectionExpanded(false);
-      setEffortSectionExpanded(false);
-      setServiceTierSectionExpanded(false);
     },
     [onAgentChange],
   );
 
-  const handleAgentRowClick = useCallback(
-    (entry: AgentStatus) => {
-      handleAgentSelect(entry.name, entry.default_model_id || entry.current_model_id || "");
-    },
-    [handleAgentSelect],
-  );
-
-  const handleSubmenuToggle = useCallback((entry: AgentStatus) => {
-    if (
-      (entry.models?.length ?? 0) === 0 &&
-      (entry.modes?.length ?? 0) === 0 &&
-      (entry.efforts?.length ?? 0) === 0 &&
-      !entry.supports_fast_service
-    ) {
-      return;
-    }
-    setErrorAgent(null);
-    setModelSectionExpanded(true);
-    setModeSectionExpanded(false);
-    setEffortSectionExpanded(false);
-    setServiceTierSectionExpanded(false);
-    const node = agentColumnRef.current;
-    if (node) {
-      setMenuBodyHeight(
-        Math.min(
-          AGENT_MENU_MAX_BODY_HEIGHT,
-          Math.max(node.scrollHeight, AGENT_MENU_MIN_BODY_HEIGHT),
-        ),
-      );
-    }
-    setSubmenuAgent((prev) => (prev === entry.name ? null : entry.name));
-  }, []);
-
-  const handleEffortSelect = useCallback(
-    (nextEffort: string) => {
-      onEffortChange?.(nextEffort);
-      setIsOpen(false);
-      setSubmenuAgent(null);
-      setErrorAgent(null);
-      setModelSectionExpanded(true);
-      setModeSectionExpanded(false);
-      setEffortSectionExpanded(false);
-      setServiceTierSectionExpanded(false);
-      setMenuBodyHeight(null);
-    },
-    [onEffortChange],
-  );
-
-  const handleServiceTierSelect = useCallback(
-    (nextFastService: "" | "on" | "off") => {
-      onFastServiceChange?.(nextFastService);
-      setIsOpen(false);
-      setSubmenuAgent(null);
-      setErrorAgent(null);
-      setModelSectionExpanded(true);
-      setModeSectionExpanded(false);
-      setEffortSectionExpanded(false);
-      setServiceTierSectionExpanded(false);
-      setMenuBodyHeight(null);
-    },
-    [onFastServiceChange],
-  );
-
-  const handleModeSelect = useCallback(
-    (nextMode: string) => {
-      onModeChange?.(nextMode);
-      setIsOpen(false);
-      setSubmenuAgent(null);
-      setErrorAgent(null);
-      setModelSectionExpanded(true);
-      setModeSectionExpanded(false);
-      setEffortSectionExpanded(false);
-      setServiceTierSectionExpanded(false);
-      setMenuBodyHeight(null);
-    },
-    [onModeChange],
-  );
-
   const handleAgentRestart = useCallback(
     async (targetAgent: string) => {
-      if (!onAgentRestart || restartingAgent) {
-        return;
-      }
+      if (!onAgentRestart || restartingAgent) return;
       setRestartingAgent(targetAgent);
       try {
         await onAgentRestart(targetAgent);
       } finally {
-        setRestartingAgent((current) =>
-          current === targetAgent ? null : current,
-        );
+        setRestartingAgent((current) => (current === targetAgent ? null : current));
       }
     },
     [onAgentRestart, restartingAgent],
@@ -364,71 +122,35 @@ export function AgentSelector({
       <button
         type="button"
         onClick={() => {
-          setIsOpen((prev) => {
-            const next = !prev;
-            if (!next) {
-              setSubmenuAgent(null);
-              setErrorAgent(null);
-              setModelSectionExpanded(true);
-              setModeSectionExpanded(false);
-              setEffortSectionExpanded(false);
-              setServiceTierSectionExpanded(false);
-              setMenuBodyHeight(null);
-            }
-            return next;
-          });
+          setIsOpen((previous) => !previous);
+          setErrorAgent(null);
         }}
-        title={buttonTitle}
+        title={warnUnavailable ? `当前会话的 Agent（${agent}）不可用` : agent || "选择 Agent"}
+        aria-label={`选择 Agent，当前为 ${agent || "未选择"}`}
         style={{
           display: "flex",
           alignItems: "center",
           gap: "4px",
-          padding: compact ? "4px 4px" : "6px 8px",
+          padding: compact ? "4px" : "6px 8px",
           borderRadius: "12px",
           border: "none",
           background: "transparent",
+          color: "var(--text-primary)",
           cursor: "pointer",
-          fontSize: "16px",
-          transition: "background 0.2s",
           outline: "none",
           position: "relative",
         }}
-        onMouseEnter={(e) => {
-          if (compact) e.currentTarget.style.background = "rgba(0,0,0,0.05)";
-        }}
-        onMouseLeave={(e) => {
-          if (compact) e.currentTarget.style.background = "transparent";
-        }}
       >
-        <AgentIcon
-          agentName={agent}
-          style={{ width: "16px", height: "16px" }}
-        />
-        {showChevron ? (
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-            style={{ color: "var(--text-secondary)" }}
-          >
-            <path d="m6 9 6 6 6-6" />
-          </svg>
-        ) : null}
-        {warnUnavailable && (
+        <AgentIcon agentName={agent} style={{ width: "16px", height: "16px" }} />
+        {showChevron ? <SelectorChevron expanded={isOpen} /> : null}
+        {warnUnavailable ? (
           <span
             style={{
               position: "absolute",
-              top: "3px",
-              right: "3px",
+              top: "1px",
+              right: "1px",
               minWidth: "11px",
               height: "11px",
-              padding: "0 2px",
               borderRadius: "50%",
               background: "#d97706",
               color: "#fff",
@@ -436,15 +158,14 @@ export function AgentSelector({
               lineHeight: "11px",
               fontWeight: 700,
               textAlign: "center",
-              boxShadow: "0 0 0 1px rgba(255,255,255,0.95)",
             }}
           >
             !
           </span>
-        )}
+        ) : null}
       </button>
 
-      {isOpen && (
+      {isOpen ? (
         <div
           style={{
             position: "absolute",
@@ -452,616 +173,137 @@ export function AgentSelector({
               ? { top: "calc(100% + 8px)" }
               : { bottom: "calc(100% + 8px)" }),
             right: 0,
-            background: "var(--menu-bg)",
+            display: "flex",
+            maxWidth: "calc(100vw - 16px)",
+            maxHeight: "360px",
+            padding: "8px 0",
             border: "1px solid var(--menu-border)",
             borderRadius: "12px",
+            background: "var(--menu-bg)",
             boxShadow: "0 8px 32px rgba(0,0,0,0.15)",
             zIndex: 1000,
-            width: "max-content",
-            minWidth: "0",
-            maxWidth: "calc(100vw - 16px)",
-            padding: "8px 0",
-            display: "flex",
-            alignItems: "stretch",
-            height: menuBodyHeight ? `${menuBodyHeight + 16}px` : "auto",
-            maxHeight: "360px",
           }}
         >
-          <div
-            ref={agentColumnRef}
-            style={{
-              width: "fit-content",
-              minWidth: "0",
-              maxWidth:
-                submenuAgentStatus || errorAgentStatus
-                  ? "min(44vw, 180px)"
-                  : "min(72vw, 180px)",
-              height: menuBodyHeight ? `${menuBodyHeight}px` : "auto",
-              maxHeight: `${AGENT_MENU_MAX_BODY_HEIGHT}px`,
-              overflowY: "auto",
-            }}
-          >
+          <div style={{ width: "min(72vw, 180px)", maxHeight: "344px", overflowY: "auto" }}>
             <div
               style={{
                 padding: "6px 12px",
                 fontSize: "11px",
-                fontWeight: 600,
+                fontWeight: 700,
                 color: "var(--text-secondary)",
                 textTransform: "uppercase",
               }}
             >
               Agent
             </div>
-            {agents.map((a) => {
-              const hasModelOptions =
-                (a.models?.length ?? 0) > 0 ||
-                (a.modes?.length ?? 0) > 0 ||
-                (a.efforts?.length ?? 0) > 0 ||
-                !!a.supports_fast_service;
-              const hasError = !a.available && !!a.error;
-              const isSelected = a.name === agent;
-              const isExpanded = submenuAgent === a.name;
-              const isShowingError = errorAgent === a.name;
+            {agents.map((item) => {
+              const selected = item.name === agent;
+              const hasError = !item.available && !!item.error;
               return (
                 <div
-                  key={a.name}
+                  key={item.name}
                   style={{
-                    minWidth: "100%",
+                    display: "grid",
+                    gridTemplateColumns: "20px minmax(0, 1fr) 20px",
+                    alignItems: "center",
+                    gap: "6px",
+                    padding: "10px 12px",
+                    background: selected ? "rgba(59, 130, 246, 0.08)" : "transparent",
                   }}
                 >
-                  <div
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: "20px minmax(0, 1fr) 18px 18px",
-                      alignItems: "center",
-                      columnGap: "4px",
-                      width: "100%",
-                      padding: "10px 12px",
-                      background:
-                        isExpanded || isSelected
-                          ? "rgba(59, 130, 246, 0.08)"
-                          : "transparent",
-                      opacity: 1,
-                    }}
+                  <button
+                    type="button"
+                    onClick={() => handleAgentSelect(item.name)}
+                    style={{ display: "contents", cursor: "pointer" }}
                   >
-                    <button
-                      type="button"
-                      onClick={() => handleAgentRowClick(a)}
+                    <AgentIcon agentName={item.name} style={{ width: "16px", height: "16px" }} />
+                    <span
                       style={{
-                        display: "contents",
-                        border: "none",
-                        background: "transparent",
-                        padding: 0,
-                        margin: 0,
-                        cursor: "pointer",
+                        minWidth: 0,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        color: selected ? "#3b82f6" : "var(--text-primary)",
+                        fontSize: "13px",
+                        fontWeight: selected ? 600 : 400,
                         textAlign: "left",
                       }}
                     >
-                      <AgentIcon
-                        agentName={a.name}
-                        style={{ width: "16px", height: "16px" }}
-                      />
-                      <span
-                        style={{
-                          minWidth: 0,
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          fontSize: "13px",
-                          color:
-                            isExpanded || isSelected
-                              ? "#3b82f6"
-                              : "var(--text-primary)",
-                          fontWeight: isExpanded || isSelected ? 500 : 400,
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {a.name}
-                      </span>
+                      {item.name}
+                    </span>
+                  </button>
+                  {hasError ? (
+                    <button
+                      type="button"
+                      aria-label={`查看 ${item.name} 错误信息`}
+                      onClick={() => setErrorAgent((current) => (current === item.name ? null : item.name))}
+                      style={{
+                        width: "20px",
+                        height: "20px",
+                        padding: 0,
+                        border: "1px solid var(--menu-border)",
+                        borderRadius: "50%",
+                        background: errorAgent === item.name ? "rgba(217,119,6,0.12)" : "transparent",
+                        color: "#d97706",
+                        cursor: "pointer",
+                        fontWeight: 700,
+                      }}
+                    >
+                      ?
                     </button>
-                    {hasError ? (
-                      <button
-                        type="button"
-                        aria-label={`查看 ${a.name} 错误信息`}
-                        onClick={(event) => {
-                          event.preventDefault();
-                          event.stopPropagation();
-                          setSubmenuAgent(null);
-                          setModelSectionExpanded(true);
-                          setModeSectionExpanded(false);
-                          setEffortSectionExpanded(false);
-                          setServiceTierSectionExpanded(false);
-                          setErrorAgent((prev) =>
-                            prev === a.name ? null : a.name,
-                          );
-                        }}
-                        style={{
-                          display: "inline-flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          width: "18px",
-                          height: "18px",
-                          borderRadius: "999px",
-                          border: "1px solid var(--menu-border)",
-                          background: isShowingError
-                            ? "rgba(217, 119, 6, 0.12)"
-                            : "transparent",
-                          color: "#d97706",
-                          fontSize: "11px",
-                          fontWeight: 700,
-                          cursor: "pointer",
-                          justifySelf: "center",
-                        }}
-                      >
-                        ?
-                      </button>
-                    ) : (
-                      <span
-                        aria-hidden="true"
-                        style={{ width: "18px", height: "18px" }}
-                      />
-                    )}
-                    {hasModelOptions ? (
-                      <button
-                        type="button"
-                        aria-label={
-                          isExpanded
-                            ? `收起 ${a.name} 模型列表`
-                            : `展开 ${a.name} 模型列表`
-                        }
-                        onClick={(event) => {
-                          event.preventDefault();
-                          event.stopPropagation();
-                          handleSubmenuToggle(a);
-                        }}
-                        style={{
-                          display: "inline-flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          width: "18px",
-                          height: "18px",
-                          borderRadius: "6px",
-                          border: "none",
-                          background: "transparent",
-                          color: isExpanded
-                            ? "#3b82f6"
-                            : "var(--text-secondary)",
-                          cursor: "pointer",
-                          justifySelf: "center",
-                        }}
-                      >
-                        <SelectorChevron expanded={isExpanded} />
-                      </button>
-                    ) : (
-                      <span
-                        aria-hidden="true"
-                        style={{ width: "18px", height: "18px" }}
-                      />
-                    )}
-                  </div>
+                  ) : (
+                    <span />
+                  )}
                 </div>
               );
             })}
           </div>
 
-          <div
-            style={{
-              width:
-                submenuAgentStatus || errorAgentStatus ? "fit-content" : "0",
-              minWidth: submenuAgentStatus || errorAgentStatus ? "0" : "0",
-              maxWidth:
-                submenuAgentStatus || errorAgentStatus
-                  ? "min(40vw, 180px)"
-                  : "0",
-              borderLeft:
-                submenuAgentStatus || errorAgentStatus
-                  ? "1px solid var(--menu-divider)"
-                  : "none",
-              height: menuBodyHeight ? `${menuBodyHeight}px` : "auto",
-              maxHeight: `${AGENT_MENU_MAX_BODY_HEIGHT}px`,
-              overflowY: "auto",
-              overflowX: "hidden",
-              transition: "width 0.16s ease, border-left-color 0.16s ease",
-              boxSizing: "border-box",
-            }}
-          >
-            {errorAgentStatus &&
-            parseAgentErrorMessage(errorAgentStatus.error) ? (
-              <div
-                style={{
-                  width: "100%",
-                  minWidth: 0,
-                  padding: "12px",
-                  boxSizing: "border-box",
-                }}
-              >
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    gap: "8px",
-                    marginBottom: "8px",
-                  }}
-                >
-                  <div
-                    style={{
-                      fontSize: "11px",
-                      fontWeight: 600,
-                      color: "#d97706",
-                      textTransform: "uppercase",
-                    }}
+          {errorAgentStatus && parseAgentErrorMessage(errorAgentStatus.error) ? (
+            <div
+              style={{
+                width: "min(44vw, 220px)",
+                padding: "12px",
+                borderLeft: "1px solid var(--menu-divider)",
+                overflowY: "auto",
+                boxSizing: "border-box",
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "8px" }}>
+                <span style={{ fontSize: "11px", fontWeight: 700, color: "#d97706" }}>错误信息</span>
+                {onAgentRestart ? (
+                  <button
+                    type="button"
+                    title="重启 Agent"
+                    disabled={restartingAgent === errorAgentStatus.name}
+                    onClick={() => void handleAgentRestart(errorAgentStatus.name)}
+                    style={{ border: "none", background: "transparent", color: "#d97706", cursor: "pointer" }}
                   >
-                    错误信息
-                  </div>
-                  {onAgentRestart ? (
-                    <button
-                      type="button"
-                      aria-label={`重启 ${errorAgentStatus.name}`}
-                      title="重启 Agent"
-                      disabled={restartingAgent === errorAgentStatus.name}
-                      onClick={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        void handleAgentRestart(errorAgentStatus.name);
-                      }}
+                    <span
+                      aria-hidden="true"
                       style={{
-                        display: "inline-flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        width: "22px",
-                        height: "22px",
-                        borderRadius: "7px",
-                        border: "none",
-                        background: "transparent",
-                        color: "#d97706",
-                        cursor:
-                          restartingAgent === errorAgentStatus.name
-                            ? "default"
-                            : "pointer",
-                        opacity:
-                          restartingAgent === errorAgentStatus.name ? 0.62 : 1,
-                        padding: 0,
-                        flex: "0 0 auto",
+                        display: "inline-block",
+                        animation: restartingAgent === errorAgentStatus.name ? "agent-refresh-spin 0.9s linear infinite" : undefined,
                       }}
                     >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="1em"
-                        height="1em"
-                        viewBox="0 0 24 24"
-                        aria-hidden="true"
-                        style={{
-                          transformOrigin: "50% 50%",
-                          animation:
-                            restartingAgent === errorAgentStatus.name
-                              ? "agent-refresh-spin 0.9s linear infinite"
-                              : undefined,
-                        }}
-                      >
-                        <path d="M0 0h24v24H0z" fill="none" />
-                        <path
-                          fill="currentColor"
-                          d="M12 20q-3.35 0-5.675-2.325T4 12t2.325-5.675T12 4q1.725 0 3.3.712T18 6.75V5q0-.425.288-.712T19 4t.713.288T20 5v5q0 .425-.288.713T19 11h-5q-.425 0-.712-.288T13 10t.288-.712T14 9h3.2q-.8-1.4-2.187-2.2T12 6Q9.5 6 7.75 7.75T6 12t1.75 4.25T12 18q1.7 0 3.113-.862t2.187-2.313q.2-.35.563-.487t.737-.013q.4.125.575.525t-.025.75q-1.025 2-2.925 3.2T12 20"
-                        />
-                      </svg>
-                    </button>
-                  ) : null}
-                </div>
-                <div
-                  style={{
-                    padding: "10px 12px",
-                    borderRadius: "10px",
-                    background: "rgba(217, 119, 6, 0.08)",
-                    border: "1px solid rgba(217, 119, 6, 0.18)",
-                    color: "var(--text-primary)",
-                    fontSize: "12px",
-                    lineHeight: 1.5,
-                    whiteSpace: "normal",
-                    overflowWrap: "anywhere",
-                    wordBreak: "break-word",
-                  }}
-                >
-                  {parseAgentErrorMessage(errorAgentStatus.error)}
-                </div>
-                {parseAgentErrorDetails(errorAgentStatus.error).map(
-                  (detail) => (
-                    <div
-                      key={detail}
-                      style={{
-                        marginTop: "8px",
-                        padding: "10px 12px",
-                        borderRadius: "10px",
-                        background: "rgba(0, 0, 0, 0.03)",
-                        border: "1px solid var(--menu-divider)",
-                        color: "var(--text-secondary)",
-                        fontSize: "11px",
-                        lineHeight: 1.5,
-                        whiteSpace: "normal",
-                        overflowWrap: "anywhere",
-                        wordBreak: "break-word",
-                      }}
-                    >
-                      {detail}
-                    </div>
-                  ),
-                )}
+                      ↻
+                    </span>
+                  </button>
+                ) : null}
               </div>
-            ) : submenuAgentStatus ? (
-              <>
-                <SectionHeader
-                  title="模型"
-                  expanded={modelSectionExpanded}
-                  onToggle={() => setModelSectionExpanded((prev) => !prev)}
-                  value={submenuSelectedModel?.id || undefined}
-                />
-                {modelSectionExpanded ? (
-                  <>
-                    {submenuModels.map((item, index) => {
-                      const isSelected =
-                        submenuAgentStatus.name === agent &&
-                        item.id === (submenuSelectedModel?.id || "");
-                      return (
-                        <button
-                          key={item.id}
-                          type="button"
-                          onClick={() =>
-                            handleAgentSelect(submenuAgentStatus.name, item.id)
-                          }
-                          style={sectionItemStyle(
-                            isSelected,
-                            index > 0,
-                            item.hidden ? 0.66 : 1,
-                          )}
-                          title={item.description || item.id}
-                        >
-                          <span style={{ fontSize: "13px", fontWeight: 500 }}>
-                            {item.name || item.id}
-                          </span>
-                          {item.description ? (
-                            <span
-                              style={{
-                                fontSize: "11px",
-                                color: "var(--text-secondary)",
-                                whiteSpace: "normal",
-                                overflowWrap: "anywhere",
-                                wordBreak: "break-word",
-                              }}
-                            >
-                              {item.description}
-                            </span>
-                          ) : item.hidden ? (
-                            <span
-                              style={{
-                                fontSize: "11px",
-                                color: "var(--text-secondary)",
-                              }}
-                            >
-                              hidden
-                            </span>
-                          ) : null}
-                        </button>
-                      );
-                    })}
-                  </>
-                ) : null}
-                {submenuModes.length > 0 ? (
-                  <>
-                    <SectionHeader
-                      title="模式"
-                      expanded={modeSectionExpanded}
-                      onToggle={() => setModeSectionExpanded((prev) => !prev)}
-                      topBorder={
-                        modelSectionExpanded ||
-                        submenuModels.length > 0 ||
-                        !!submenuSelectedModel?.id
-                      }
-                      value={displayedMode || undefined}
-                    />
-                    {modeSectionExpanded ? (
-                      <>
-                        {submenuModes.map((item, index) => (
-                          <button
-                            key={item.id}
-                            type="button"
-                            onClick={() => handleModeSelect(item.id)}
-                            style={sectionItemStyle(
-                              item.id === displayedMode,
-                              index > 0,
-                            )}
-                            title={item.description || item.id}
-                          >
-                            <span style={{ fontSize: "13px", fontWeight: 500 }}>
-                              {item.name || item.id}
-                            </span>
-                            {item.description ? (
-                              <span
-                                style={{
-                                  fontSize: "11px",
-                                  color: "var(--text-secondary)",
-                                  whiteSpace: "normal",
-                                  overflowWrap: "anywhere",
-                                  wordBreak: "break-word",
-                                }}
-                              >
-                                {item.description}
-                              </span>
-                            ) : null}
-                          </button>
-                        ))}
-                      </>
-                    ) : null}
-                  </>
-                ) : null}
-                {submenuSupportsEffort ? (
-                  <>
-                    <SectionHeader
-                      title="思考等级"
-                      expanded={effortSectionExpanded}
-                      onToggle={() => setEffortSectionExpanded((prev) => !prev)}
-                      topBorder={
-                        modelSectionExpanded ||
-                        submenuModels.length > 0 ||
-                        !!submenuSelectedModel?.id ||
-                        submenuModes.length > 0
-                      }
-                      value={displayedEffort}
-                    />
-                    {effortSectionExpanded ? (
-                      <>
-                        {submenuEfforts.map((item, index) => (
-                          <button
-                            key={item}
-                            type="button"
-                            onClick={() => handleEffortSelect(item)}
-                            style={sectionItemStyle(
-                              item === displayedEffort.toLowerCase(),
-                              index > 0,
-                            )}
-                          >
-                            <span
-                              style={{
-                                fontSize: "13px",
-                                fontWeight: 500,
-                                textTransform: "capitalize",
-                              }}
-                            >
-                              {item}
-                            </span>
-                          </button>
-                        ))}
-                      </>
-                    ) : null}
-                  </>
-                ) : null}
-                {submenuSupportsServiceTier ? (
-                  <>
-                    <SectionHeader
-                      title="Fast 模式"
-                      expanded={serviceTierSectionExpanded}
-                      onToggle={() =>
-                        setServiceTierSectionExpanded((prev) => !prev)
-                      }
-                      topBorder={
-                        modelSectionExpanded ||
-                        submenuModels.length > 0 ||
-                        !!submenuSelectedModel?.id ||
-                        submenuModes.length > 0 ||
-                        submenuSupportsEffort
-                      }
-                      value={fastModeEnabled ? "开启" : "关闭"}
-                    />
-                    {serviceTierSectionExpanded ? (
-                      <>
-                        {(["off", "on"] as const).map((item, index) => (
-                          <button
-                            key={item}
-                            type="button"
-                            onClick={() => handleServiceTierSelect(item)}
-                            style={sectionItemStyle(
-                              (item === "on") === fastModeEnabled,
-                              index > 0,
-                            )}
-                          >
-                            <span
-                              style={{
-                                fontSize: "13px",
-                                fontWeight: 500,
-                              }}
-                            >
-                              {item === "on" ? "开启" : "关闭"}
-                            </span>
-                          </button>
-                        ))}
-                      </>
-                    ) : null}
-                  </>
-                ) : null}
-              </>
-            ) : null}
-          </div>
+              <div style={{ marginTop: "8px", fontSize: "12px", lineHeight: 1.5, color: "var(--text-primary)", overflowWrap: "anywhere" }}>
+                {parseAgentErrorMessage(errorAgentStatus.error)}
+              </div>
+              {parseAgentErrorDetails(errorAgentStatus.error).map((detail) => (
+                <div key={detail} style={{ marginTop: "8px", fontSize: "11px", lineHeight: 1.5, color: "var(--text-secondary)", overflowWrap: "anywhere" }}>
+                  {detail}
+                </div>
+              ))}
+            </div>
+          ) : null}
         </div>
-      )}
+      ) : null}
     </div>
-  );
-}
-
-function SectionHeader({
-  title,
-  expanded,
-  onToggle,
-  topBorder = false,
-  value,
-}: {
-  title: string;
-  expanded: boolean;
-  onToggle: () => void;
-  topBorder?: boolean;
-  value?: string;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        width: "100%",
-        minWidth: 0,
-        padding: "10px 12px",
-        border: "none",
-        borderTop: topBorder ? "1px solid var(--menu-divider)" : "none",
-        background: expanded ? "rgba(59, 130, 246, 0.05)" : "transparent",
-        color: "var(--text-primary)",
-        textAlign: "left",
-        cursor: "pointer",
-      }}
-    >
-      <span
-        style={{
-          flex: "0 0 auto",
-          fontSize: "11px",
-          fontWeight: 700,
-          letterSpacing: "0.08em",
-          textTransform: "uppercase",
-          color: expanded ? "#3b82f6" : "var(--text-secondary)",
-          whiteSpace: "nowrap",
-        }}
-      >
-        {title}
-      </span>
-      <span
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          justifyContent: "flex-end",
-          gap: "8px",
-          flex: "1 1 auto",
-          minWidth: 0,
-          marginLeft: "8px",
-        }}
-      >
-        {value ? (
-          <span
-            title={value}
-            style={{
-              minWidth: 0,
-              fontSize: "11px",
-              color: "var(--text-secondary)",
-              whiteSpace: "nowrap",
-              maxWidth: "92px",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              direction: "rtl",
-              textAlign: "left",
-            }}
-          >
-            {value}
-          </span>
-        ) : null}
-        <SelectorChevron expanded={expanded} />
-      </span>
-    </button>
   );
 }
 
@@ -1075,41 +317,12 @@ function SelectorChevron({ expanded }: { expanded: boolean }) {
       aria-hidden="true"
       style={{
         flexShrink: 0,
-        color: expanded ? "#3b82f6" : "#9ca3af",
-        transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
+        color: expanded ? "#3b82f6" : "var(--text-secondary)",
+        transform: expanded ? "rotate(180deg)" : "none",
         transition: "transform 0.16s ease",
       }}
     >
-      <path
-        d="M4 2.5 8 6 4 9.5"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <path d="m2.5 4 3.5 4 3.5-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
-}
-
-function sectionItemStyle(
-  selected: boolean,
-  topBorder = false,
-  opacity = 1,
-): React.CSSProperties {
-  return {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "flex-start",
-    gap: "2px",
-    width: "100%",
-    minWidth: 0,
-    padding: "10px 12px",
-    border: "none",
-    borderTop: topBorder ? "1px solid var(--menu-divider)" : "none",
-    background: selected ? "rgba(59, 130, 246, 0.08)" : "transparent",
-    color: selected ? "#3b82f6" : "var(--text-primary)",
-    textAlign: "left",
-    cursor: "pointer",
-    opacity,
-  };
 }

--- a/web/src/components/EffortSelector.tsx
+++ b/web/src/components/EffortSelector.tsx
@@ -1,24 +1,26 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import type { AgentStatus } from "../services/agents";
 
-type ModelSelectorProps = {
+type EffortSelectorProps = {
   agent?: AgentStatus | null;
   model?: string;
-  onModelChange: (model: string) => void;
+  effort?: string;
+  onEffortChange?: (effort?: string) => void;
   compact?: boolean;
   menuPlacement?: "top" | "bottom";
   maxButtonWidth?: string;
 };
 
-/** 模型选择器：独立选择模型，不包含运行参数（模式/思考等级/Fast）。 */
-export function ModelSelector({
+/** 思考等级选择器：独立选择模型的思考等级，与模型/模式/Fast 配置解耦。 */
+export function EffortSelector({
   agent,
   model = "",
-  onModelChange,
+  effort = "",
+  onEffortChange,
   compact = false,
   menuPlacement = "top",
   maxButtonWidth = "min(30vw, 132px)",
-}: ModelSelectorProps) {
+}: EffortSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const models = agent?.models ?? [];
@@ -27,8 +29,10 @@ export function ModelSelector({
     const target = model || fallback;
     return models.find((item) => item.id === target) ?? null;
   }, [agent, model, models]);
-  const displayName = selectedModel?.name || selectedModel?.id || model || "模型";
-  const hasModelContent = models.length > 0;
+  const modelEfforts = selectedModel?.efforts ?? [];
+  const efforts = modelEfforts.length > 0 ? modelEfforts : agent?.efforts ?? [];
+  const supportsEffort = efforts.length > 0 && !!selectedModel?.supportEffort;
+  const displayedEffort = effort || selectedModel?.default_effort || agent?.default_effort || "Auto";
 
   useEffect(() => {
     if (!isOpen) return;
@@ -45,16 +49,14 @@ export function ModelSelector({
 
   const closeMenu = () => setIsOpen(false);
 
-  if (!agent && !model) return null;
+  if (!supportsEffort) return null;
 
   return (
     <div ref={dropdownRef} style={{ position: "relative", minWidth: 0 }}>
       <button
         type="button"
-        disabled={!hasModelContent || !agent?.available}
         onClick={() => setIsOpen((previous) => !previous)}
-        title={selectedModel?.description || selectedModel?.id || model || "当前 Agent 未提供模型"}
-        aria-label={`选择模型，当前为 ${displayName}`}
+        aria-label={`选择思考等级，当前为 ${displayedEffort}`}
         style={{
           display: "inline-flex",
           alignItems: "center",
@@ -65,9 +67,8 @@ export function ModelSelector({
           border: "none",
           borderRadius: "10px",
           background: isOpen ? "rgba(59,130,246,0.08)" : "transparent",
-          color: agent?.available === false ? "var(--text-secondary)" : "var(--text-primary)",
-          cursor: hasModelContent && agent?.available !== false ? "pointer" : "default",
-          opacity: hasModelContent ? 1 : 0.58,
+          color: "var(--text-primary)",
+          cursor: "pointer",
           outline: "none",
         }}
       >
@@ -79,9 +80,10 @@ export function ModelSelector({
             whiteSpace: "nowrap",
             fontSize: "12px",
             fontWeight: 600,
+            textTransform: "capitalize",
           }}
         >
-          {displayName}
+          {displayedEffort}
         </span>
         <SelectorChevron expanded={isOpen} />
       </button>
@@ -105,19 +107,17 @@ export function ModelSelector({
             zIndex: 1000,
           }}
         >
-          {models.map((item, index) => (
+          {efforts.map((item, index) => (
             <button
-              key={item.id}
+              key={item}
               type="button"
               onClick={() => {
-                onModelChange(item.id);
+                onEffortChange?.(item);
                 closeMenu();
               }}
-              title={item.description || item.id}
-              style={sectionItemStyle(item.id === selectedModel?.id, index > 0, item.hidden ? 0.66 : 1)}
+              style={sectionItemStyle(item === displayedEffort.toLowerCase(), index > 0)}
             >
-              <span style={{ fontSize: "13px", fontWeight: 600 }}>{item.name || item.id}</span>
-              {item.description ? <span style={descriptionStyle}>{item.description}</span> : null}
+              <span style={{ fontSize: "13px", fontWeight: 600, textTransform: "capitalize" }}>{item}</span>
             </button>
           ))}
         </div>
@@ -125,14 +125,6 @@ export function ModelSelector({
     </div>
   );
 }
-
-const descriptionStyle: React.CSSProperties = {
-  fontSize: "11px",
-  color: "var(--text-secondary)",
-  whiteSpace: "normal",
-  overflowWrap: "anywhere",
-  wordBreak: "break-word",
-};
 
 function SelectorChevron({ expanded }: { expanded: boolean }) {
   return (
@@ -154,7 +146,7 @@ function SelectorChevron({ expanded }: { expanded: boolean }) {
   );
 }
 
-function sectionItemStyle(selected: boolean, topBorder = false, opacity = 1): React.CSSProperties {
+function sectionItemStyle(selected: boolean, topBorder = false): React.CSSProperties {
   return {
     display: "flex",
     flexDirection: "column",
@@ -169,6 +161,5 @@ function sectionItemStyle(selected: boolean, topBorder = false, opacity = 1): Re
     color: selected ? "#3b82f6" : "var(--text-primary)",
     textAlign: "left",
     cursor: "pointer",
-    opacity,
   };
 }

--- a/web/src/components/FastServiceSelector.tsx
+++ b/web/src/components/FastServiceSelector.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import type { AgentStatus } from "../services/agents";
+
+type FastServiceSelectorProps = {
+  agent?: AgentStatus | null;
+  fastService?: "" | "on" | "off";
+  onFastServiceChange?: (fastService?: "" | "on" | "off") => void;
+  compact?: boolean;
+};
+
+/** Fast 模式开关：灰色关闭，蓝色开启，点击直接切换。 */
+export function FastServiceSelector({
+  agent,
+  fastService = "",
+  onFastServiceChange,
+  compact = false,
+}: FastServiceSelectorProps) {
+  const supportsFastService = !!agent?.supports_fast_service;
+  const fastModeEnabled = (fastService || agent?.default_fast_service || "") === "on";
+
+  if (!supportsFastService) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onFastServiceChange?.(fastModeEnabled ? "off" : "on")}
+      aria-label={`Fast 模式，当前为 ${fastModeEnabled ? "开启" : "关闭"}`}
+      title={`Fast 模式：${fastModeEnabled ? "开启" : "关闭"}`}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "4px",
+        height: compact ? "28px" : "32px",
+        padding: compact ? "0 5px" : "0 8px",
+        border: "none",
+        borderRadius: "10px",
+        background: fastModeEnabled ? "rgba(59,130,246,0.15)" : "transparent",
+        color: fastModeEnabled ? "#3b82f6" : "var(--text-secondary)",
+        cursor: "pointer",
+        outline: "none",
+        fontSize: "12px",
+        fontWeight: 600,
+        whiteSpace: "nowrap",
+      }}
+    >
+      <span>Fast</span>
+    </button>
+  );
+}

--- a/web/src/components/ModelSelector.tsx
+++ b/web/src/components/ModelSelector.tsx
@@ -1,0 +1,298 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import type { AgentStatus } from "../services/agents";
+
+type ModelSelectorProps = {
+  agent?: AgentStatus | null;
+  model?: string;
+  mode?: string;
+  effort?: string;
+  fastService?: "" | "on" | "off";
+  onModelChange: (model: string) => void;
+  onModeChange?: (mode?: string) => void;
+  onEffortChange?: (effort?: string) => void;
+  onFastServiceChange?: (fastService?: "" | "on" | "off") => void;
+  compact?: boolean;
+  menuPlacement?: "top" | "bottom";
+  maxButtonWidth?: string;
+};
+
+/** 模型及其相关运行参数独立于 Agent 选择，避免一个入口同时改变两类状态。 */
+export function ModelSelector({
+  agent,
+  model = "",
+  mode = "",
+  effort = "",
+  fastService = "",
+  onModelChange,
+  onModeChange,
+  onEffortChange,
+  onFastServiceChange,
+  compact = false,
+  menuPlacement = "top",
+  maxButtonWidth = "min(30vw, 132px)",
+}: ModelSelectorProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [modelExpanded, setModelExpanded] = useState(true);
+  const [modeExpanded, setModeExpanded] = useState(false);
+  const [effortExpanded, setEffortExpanded] = useState(false);
+  const [serviceTierExpanded, setServiceTierExpanded] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const models = agent?.models ?? [];
+  const selectedModel = useMemo(() => {
+    const fallback = agent?.default_model_id || agent?.current_model_id || "";
+    const target = model || fallback;
+    return models.find((item) => item.id === target) ?? null;
+  }, [agent, model, models]);
+  const modelEfforts = selectedModel?.efforts ?? [];
+  const efforts = modelEfforts.length > 0 ? modelEfforts : agent?.efforts ?? [];
+  const modes = agent?.modes ?? [];
+  const supportsEffort = efforts.length > 0 && !!selectedModel?.supportEffort;
+  const supportsFastService = !!agent?.supports_fast_service;
+  const displayedMode = mode || agent?.current_mode_id || "";
+  const displayedEffort = effort || selectedModel?.default_effort || agent?.default_effort || "Auto";
+  const fastModeEnabled = (fastService || agent?.default_fast_service || "") === "on";
+  const hasMenuContent = models.length > 0 || modes.length > 0 || supportsEffort || supportsFastService;
+  const displayName = selectedModel?.name || selectedModel?.id || model || "模型";
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handlePointerOutside = (event: PointerEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerOutside);
+    return () => document.removeEventListener("pointerdown", handlePointerOutside);
+  }, [isOpen]);
+
+  useEffect(() => setIsOpen(false), [agent?.name]);
+
+  const closeMenu = () => setIsOpen(false);
+
+  if (!agent && !model) return null;
+
+  return (
+    <div ref={dropdownRef} style={{ position: "relative", minWidth: 0 }}>
+      <button
+        type="button"
+        disabled={!hasMenuContent || !agent?.available}
+        onClick={() => setIsOpen((previous) => !previous)}
+        title={selectedModel?.description || selectedModel?.id || model || "当前 Agent 未提供模型"}
+        aria-label={`选择模型，当前为 ${displayName}`}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "4px",
+          maxWidth: maxButtonWidth,
+          height: compact ? "28px" : "32px",
+          padding: compact ? "0 5px" : "0 8px",
+          border: "none",
+          borderRadius: "10px",
+          background: isOpen ? "rgba(59,130,246,0.08)" : "transparent",
+          color: agent?.available === false ? "var(--text-secondary)" : "var(--text-primary)",
+          cursor: hasMenuContent && agent?.available !== false ? "pointer" : "default",
+          opacity: hasMenuContent ? 1 : 0.58,
+          outline: "none",
+        }}
+      >
+        <span
+          style={{
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            fontSize: "12px",
+            fontWeight: 600,
+          }}
+        >
+          {displayName}
+        </span>
+        <SelectorChevron expanded={isOpen} />
+      </button>
+
+      {isOpen ? (
+        <div
+          style={{
+            position: "absolute",
+            ...(menuPlacement === "bottom"
+              ? { top: "calc(100% + 8px)" }
+              : { bottom: "calc(100% + 8px)" }),
+            right: 0,
+            width: "min(280px, calc(100vw - 16px))",
+            maxHeight: "360px",
+            overflowY: "auto",
+            padding: "8px 0",
+            border: "1px solid var(--menu-border)",
+            borderRadius: "12px",
+            background: "var(--menu-bg)",
+            boxShadow: "0 8px 32px rgba(0,0,0,0.15)",
+            zIndex: 1000,
+          }}
+        >
+          {models.length > 0 ? (
+            <>
+              <SectionHeader title="模型" expanded={modelExpanded} onToggle={() => setModelExpanded((value) => !value)} value={selectedModel?.id} />
+              {modelExpanded
+                ? models.map((item, index) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => {
+                        onModelChange(item.id);
+                        closeMenu();
+                      }}
+                      title={item.description || item.id}
+                      style={sectionItemStyle(item.id === selectedModel?.id, index > 0, item.hidden ? 0.66 : 1)}
+                    >
+                      <span style={{ fontSize: "13px", fontWeight: 600 }}>{item.name || item.id}</span>
+                      {item.description ? <span style={descriptionStyle}>{item.description}</span> : null}
+                    </button>
+                  ))
+                : null}
+            </>
+          ) : null}
+
+          {modes.length > 0 ? (
+            <>
+              <SectionHeader title="模式" expanded={modeExpanded} onToggle={() => setModeExpanded((value) => !value)} topBorder={models.length > 0} value={displayedMode} />
+              {modeExpanded
+                ? modes.map((item, index) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => {
+                        onModeChange?.(item.id);
+                        closeMenu();
+                      }}
+                      title={item.description || item.id}
+                      style={sectionItemStyle(item.id === displayedMode, index > 0)}
+                    >
+                      <span style={{ fontSize: "13px", fontWeight: 600 }}>{item.name || item.id}</span>
+                      {item.description ? <span style={descriptionStyle}>{item.description}</span> : null}
+                    </button>
+                  ))
+                : null}
+            </>
+          ) : null}
+
+          {supportsEffort ? (
+            <>
+              <SectionHeader title="思考等级" expanded={effortExpanded} onToggle={() => setEffortExpanded((value) => !value)} topBorder={models.length > 0 || modes.length > 0} value={displayedEffort} />
+              {effortExpanded
+                ? efforts.map((item, index) => (
+                    <button
+                      key={item}
+                      type="button"
+                      onClick={() => {
+                        onEffortChange?.(item);
+                        closeMenu();
+                      }}
+                      style={sectionItemStyle(item === displayedEffort.toLowerCase(), index > 0)}
+                    >
+                      <span style={{ fontSize: "13px", fontWeight: 600, textTransform: "capitalize" }}>{item}</span>
+                    </button>
+                  ))
+                : null}
+            </>
+          ) : null}
+
+          {supportsFastService ? (
+            <>
+              <SectionHeader title="Fast 模式" expanded={serviceTierExpanded} onToggle={() => setServiceTierExpanded((value) => !value)} topBorder={models.length > 0 || modes.length > 0 || supportsEffort} value={fastModeEnabled ? "开启" : "关闭"} />
+              {serviceTierExpanded
+                ? (["off", "on"] as const).map((item, index) => (
+                    <button
+                      key={item}
+                      type="button"
+                      onClick={() => {
+                        onFastServiceChange?.(item);
+                        closeMenu();
+                      }}
+                      style={sectionItemStyle((item === "on") === fastModeEnabled, index > 0)}
+                    >
+                      <span style={{ fontSize: "13px", fontWeight: 600 }}>{item === "on" ? "开启" : "关闭"}</span>
+                    </button>
+                  ))
+                : null}
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+const descriptionStyle: React.CSSProperties = {
+  fontSize: "11px",
+  color: "var(--text-secondary)",
+  whiteSpace: "normal",
+  overflowWrap: "anywhere",
+  wordBreak: "break-word",
+};
+
+function SectionHeader({ title, expanded, onToggle, topBorder = false, value }: { title: string; expanded: boolean; onToggle: () => void; topBorder?: boolean; value?: string }) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        width: "100%",
+        minWidth: 0,
+        padding: "10px 12px",
+        border: "none",
+        borderTop: topBorder ? "1px solid var(--menu-divider)" : "none",
+        background: expanded ? "rgba(59,130,246,0.05)" : "transparent",
+        color: "var(--text-primary)",
+        cursor: "pointer",
+      }}
+    >
+      <span style={{ fontSize: "11px", fontWeight: 700, color: expanded ? "#3b82f6" : "var(--text-secondary)" }}>{title}</span>
+      <span style={{ display: "inline-flex", alignItems: "center", minWidth: 0, gap: "8px" }}>
+        {value ? <span title={value} style={{ maxWidth: "130px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", fontSize: "11px", color: "var(--text-secondary)" }}>{value}</span> : null}
+        <SelectorChevron expanded={expanded} side />
+      </span>
+    </button>
+  );
+}
+
+function SelectorChevron({ expanded, side = false }: { expanded: boolean; side?: boolean }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      aria-hidden="true"
+      style={{
+        flexShrink: 0,
+        color: expanded ? "#3b82f6" : "var(--text-secondary)",
+        transform: side ? (expanded ? "rotate(90deg)" : "none") : expanded ? "rotate(180deg)" : "none",
+        transition: "transform 0.16s ease",
+      }}
+    >
+      <path d={side ? "M4 2.5 8 6 4 9.5" : "m2.5 4 3.5 4 3.5-4"} stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function sectionItemStyle(selected: boolean, topBorder = false, opacity = 1): React.CSSProperties {
+  return {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    gap: "2px",
+    width: "100%",
+    minWidth: 0,
+    padding: "10px 12px",
+    border: "none",
+    borderTop: topBorder ? "1px solid var(--menu-divider)" : "none",
+    background: selected ? "rgba(59,130,246,0.08)" : "transparent",
+    color: selected ? "#3b82f6" : "var(--text-primary)",
+    textAlign: "left",
+    cursor: "pointer",
+    opacity,
+  };
+}

--- a/web/src/components/ScheduledAgentTaskDialog.tsx
+++ b/web/src/components/ScheduledAgentTaskDialog.tsx
@@ -2,6 +2,9 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AgentIcon } from "./AgentIcon";
 import { AgentSelector } from "./AgentSelector";
 import { ModelSelector } from "./ModelSelector";
+import { AgentModeSelector } from "./AgentModeSelector";
+import { EffortSelector } from "./EffortSelector";
+import { FastServiceSelector } from "./FastServiceSelector";
 import { renderToolIcon } from "./stream/ToolCallCard";
 import type { AgentStatus } from "../services/agents";
 import {
@@ -1010,9 +1013,6 @@ export function ScheduledAgentTaskDialog({
               <ModelSelector
                 agent={formAgentStatus}
                 model={form.model}
-                mode={form.mode}
-                effort={form.effort}
-                fastService={form.fast_service}
                 compact
                 menuPlacement="bottom"
                 maxButtonWidth="112px"
@@ -1025,8 +1025,28 @@ export function ScheduledAgentTaskDialog({
                     fast_service: "",
                   }))
                 }
+              />
+              <AgentModeSelector
+                agent={formAgentStatus}
+                mode={form.mode}
+                compact
+                menuPlacement="bottom"
+                maxButtonWidth="112px"
                 onModeChange={(mode) => setForm((prev) => ({ ...prev, mode: mode || "" }))}
+              />
+              <EffortSelector
+                agent={formAgentStatus}
+                model={form.model}
+                effort={form.effort}
+                compact
+                menuPlacement="bottom"
+                maxButtonWidth="112px"
                 onEffortChange={(effort) => setForm((prev) => ({ ...prev, effort: effort || "" }))}
+              />
+              <FastServiceSelector
+                agent={formAgentStatus}
+                fastService={form.fast_service}
+                compact
                 onFastServiceChange={(fastService) => setForm((prev) => ({ ...prev, fast_service: fastService || "" }))}
               />
               <label

--- a/web/src/components/ScheduledAgentTaskDialog.tsx
+++ b/web/src/components/ScheduledAgentTaskDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AgentIcon } from "./AgentIcon";
 import { AgentSelector } from "./AgentSelector";
+import { ModelSelector } from "./ModelSelector";
 import { renderToolIcon } from "./stream/ToolCallCard";
 import type { AgentStatus } from "../services/agents";
 import {
@@ -36,12 +37,12 @@ type Props = {
 
 const CRON_LABELS = ["分", "时", "日", "月", "周"] as const;
 
-const emptyForm = (agent = ""): FormState => ({
+const emptyForm = (agent = "", model = ""): FormState => ({
   name: "",
   enabled: true,
   task_cron: "0 9 * * 1-5",
   agent,
-  model: "",
+  model,
   mode: "",
   effort: "",
   fast_service: "",
@@ -147,6 +148,15 @@ function taskToForm(task: ScheduledAgentTask): FormState {
     prompt: task.prompt || "",
     new_session_cron: task.new_session_cron || "",
   };
+}
+
+function modelDefaultEffort(agent: AgentStatus | null | undefined, modelID: string): string {
+  const model = agent?.models?.find((item) => item.id === modelID);
+  if (model && !model.supportEffort) return "";
+  const modelEfforts = model?.efforts ?? [];
+  const efforts = modelEfforts.length > 0 ? modelEfforts : agent?.efforts ?? [];
+  return [model?.default_effort || "", agent?.default_effort || ""]
+    .find((item) => item && efforts.includes(item)) || efforts[0] || "";
 }
 
 const fieldStyle: React.CSSProperties = {
@@ -412,9 +422,15 @@ export function ScheduledAgentTaskDialog({
   const [runningTaskId, setRunningTaskId] = useState<string | null>(null);
   const dialogBodyRef = useRef<HTMLDivElement | null>(null);
 
-  const defaultAgent = useMemo(
-    () => agents.find((item) => item.available)?.name || agents[0]?.name || "",
+  const defaultAgentStatus = useMemo(
+    () => agents.find((item) => item.available) || agents[0] || null,
     [agents],
+  );
+  const defaultAgent = defaultAgentStatus?.name || "";
+  const defaultModel = defaultAgentStatus?.default_model_id || defaultAgentStatus?.current_model_id || "";
+  const formAgentStatus = useMemo(
+    () => agents.find((item) => item.name === form.agent) || null,
+    [agents, form.agent],
   );
 
   const loadTasks = async () => {
@@ -434,9 +450,9 @@ export function ScheduledAgentTaskDialog({
     if (!open) return;
     setView("list");
     setSelected(null);
-    setForm(emptyForm(defaultAgent));
+    setForm(emptyForm(defaultAgent, defaultModel));
     void loadTasks();
-  }, [open, rootId, defaultAgent]);
+  }, [open, rootId, defaultAgent, defaultModel]);
 
   useEffect(() => {
     if (!open) return;
@@ -468,7 +484,7 @@ export function ScheduledAgentTaskDialog({
 
   const startCreate = () => {
     setSelected(null);
-    setForm(emptyForm(defaultAgent));
+    setForm(emptyForm(defaultAgent, defaultModel));
     setError("");
     setView("create");
   };
@@ -971,39 +987,47 @@ export function ScheduledAgentTaskDialog({
               新建
             </button>
           ) : (
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 4, minWidth: 0 }}>
               <AgentSelector
                 agent={form.agent}
-                model={form.model}
-                mode={form.mode}
-                effort={form.effort}
-                fastService={form.fast_service}
                 agents={agents}
                 compact
                 menuPlacement="bottom"
                 showChevron
-                onAgentChange={(agent, model) =>
+                onAgentChange={(agent) => {
+                  const status = agents.find((item) => item.name === agent) || null;
+                  const model = status?.default_model_id || status?.current_model_id || "";
                   setForm((prev) => ({
                     ...prev,
                     agent,
-                    model: model || "",
+                    model,
+                    mode: status?.current_mode_id || "",
+                    effort: modelDefaultEffort(status, model),
+                    fast_service: status?.default_fast_service === "on" ? "on" : status?.default_fast_service === "off" ? "off" : "",
+                  }));
+                }}
+              />
+              <ModelSelector
+                agent={formAgentStatus}
+                model={form.model}
+                mode={form.mode}
+                effort={form.effort}
+                fastService={form.fast_service}
+                compact
+                menuPlacement="bottom"
+                maxButtonWidth="112px"
+                onModelChange={(model) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    model,
                     mode: "",
-                    effort: "",
+                    effort: modelDefaultEffort(formAgentStatus, model),
                     fast_service: "",
                   }))
                 }
-                onModeChange={(mode) =>
-                  setForm((prev) => ({ ...prev, mode: mode || "" }))
-                }
-                onEffortChange={(effort) =>
-                  setForm((prev) => ({ ...prev, effort: effort || "" }))
-                }
-                onFastServiceChange={(fastService) =>
-                  setForm((prev) => ({
-                    ...prev,
-                    fast_service: fastService || "",
-                  }))
-                }
+                onModeChange={(mode) => setForm((prev) => ({ ...prev, mode: mode || "" }))}
+                onEffortChange={(effort) => setForm((prev) => ({ ...prev, effort: effort || "" }))}
+                onFastServiceChange={(fastService) => setForm((prev) => ({ ...prev, fast_service: fastService || "" }))}
               />
               <label
                 style={{

--- a/web/src/components/TaskTemplateDialog.tsx
+++ b/web/src/components/TaskTemplateDialog.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AgentSelector } from "./AgentSelector";
 import { ModelSelector } from "./ModelSelector";
+import { AgentModeSelector } from "./AgentModeSelector";
+import { EffortSelector } from "./EffortSelector";
+import { FastServiceSelector } from "./FastServiceSelector";
 import { AgentIcon } from "./AgentIcon";
 import {
   deleteStageTemplate,
@@ -436,25 +439,44 @@ export function TaskTemplateDialog({ open, agents, template, onClose, onSaved }:
                     }}
                   />
                   {isAgent ? (
-                    <ModelSelector
+                    <>
+                      <ModelSelector
+                        agent={selectedAgentStatus}
+                        model={snapshot.model || ""}
+                        compact
+                        menuPlacement="bottom"
+                        maxButtonWidth="132px"
+                        onModelChange={(model) =>
+                          updateStage(index, {
+                            model,
+                            effort: modelDefaultEffort(selectedAgentStatus, model),
+                          })
+                        }
+                      />
+                      <AgentModeSelector
+                        agent={selectedAgentStatus}
+                        mode={snapshot.mode || ""}
+                        compact
+                        menuPlacement="bottom"
+                        maxButtonWidth="132px"
+                        onModeChange={(mode) => updateStage(index, { mode: mode || "" })}
+                      />
+                      <EffortSelector
+                        agent={selectedAgentStatus}
+                        model={snapshot.model || ""}
+                        effort={snapshot.effort || ""}
+                        compact
+                        menuPlacement="bottom"
+                        maxButtonWidth="132px"
+                        onEffortChange={(effort) => updateStage(index, { effort: effort || "" })}
+                      />
+                    <FastServiceSelector
                       agent={selectedAgentStatus}
-                      model={snapshot.model || ""}
-                      mode={snapshot.mode || ""}
-                      effort={snapshot.effort || ""}
                       fastService={toFastService(snapshot.fast_service)}
                       compact
-                      menuPlacement="bottom"
-                      maxButtonWidth="132px"
-                      onModelChange={(model) =>
-                        updateStage(index, {
-                          model,
-                          effort: modelDefaultEffort(selectedAgentStatus, model),
-                        })
-                      }
-                      onModeChange={(mode) => updateStage(index, { mode: mode || "" })}
-                      onEffortChange={(effort) => updateStage(index, { effort: effort || "" })}
                       onFastServiceChange={(fastService) => updateStage(index, { fast_service: fastService || "" })}
                     />
+                    </>
                   ) : null}
                   <StageOptionsMenu
                     isAgent={isAgent}

--- a/web/src/components/TaskTemplateDialog.tsx
+++ b/web/src/components/TaskTemplateDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AgentSelector } from "./AgentSelector";
+import { ModelSelector } from "./ModelSelector";
 import { AgentIcon } from "./AgentIcon";
 import {
   deleteStageTemplate,
@@ -105,6 +106,15 @@ function agentDefaults(agent?: AgentStatus | null) {
     effort: agent?.default_effort || "",
     fastService: (agent?.default_fast_service || "") as "" | "on" | "off",
   };
+}
+
+function modelDefaultEffort(agent: AgentStatus | null, modelID: string): string {
+  const model = agent?.models?.find((item) => item.id === modelID);
+  if (model && !model.supportEffort) return "";
+  const modelEfforts = model?.efforts ?? [];
+  const efforts = modelEfforts.length > 0 ? modelEfforts : agent?.efforts ?? [];
+  return [model?.default_effort || "", agent?.default_effort || ""]
+    .find((item) => item && efforts.includes(item)) || efforts[0] || "";
 }
 
 export function TaskTemplateDialog({ open, agents, template, onClose, onSaved }: TaskTemplateDialogProps) {
@@ -397,10 +407,6 @@ export function TaskTemplateDialog({ open, agents, template, onClose, onSaved }:
                     role={snapshot.role}
                     disabled={index === 0}
                     agent={snapshot.agent || "codex"}
-                    model={snapshot.model || ""}
-                    mode={snapshot.mode || ""}
-                    effort={snapshot.effort || ""}
-                    fastService={toFastService(snapshot.fast_service)}
                     agents={agents}
                     onUserClick={() => updateStage(index, { ...blankUserStage(), name: snapshot.name || "" })}
                     onAgentActivate={() => {
@@ -416,22 +422,40 @@ export function TaskTemplateDialog({ open, agents, template, onClose, onSaved }:
                         ...(status?.protocol === "acp" ? { plan_mode: false } : {}),
                       });
                     }}
-                    onAgentChange={(agent, model) => {
+                    onAgentChange={(agent) => {
                       const status = agents.find((item) => item.name === agent) || null;
                       const defaults = agentDefaults(status);
                       updateStage(index, {
                         agent,
-                        model: model || defaults.model,
+                        model: defaults.model,
                         mode: status?.current_mode_id || "",
-                        effort: defaults.effort,
+                        effort: modelDefaultEffort(status, defaults.model),
                         fast_service: defaults.fastService,
                         ...(status?.protocol === "acp" ? { plan_mode: false } : {}),
                       });
                     }}
-                    onModeChange={(mode) => updateStage(index, { mode: mode || "" })}
-                    onEffortChange={(effort) => updateStage(index, { effort: effort || "" })}
-                    onFastServiceChange={(fastService) => updateStage(index, { fast_service: fastService || "" })}
                   />
+                  {isAgent ? (
+                    <ModelSelector
+                      agent={selectedAgentStatus}
+                      model={snapshot.model || ""}
+                      mode={snapshot.mode || ""}
+                      effort={snapshot.effort || ""}
+                      fastService={toFastService(snapshot.fast_service)}
+                      compact
+                      menuPlacement="bottom"
+                      maxButtonWidth="132px"
+                      onModelChange={(model) =>
+                        updateStage(index, {
+                          model,
+                          effort: modelDefaultEffort(selectedAgentStatus, model),
+                        })
+                      }
+                      onModeChange={(mode) => updateStage(index, { mode: mode || "" })}
+                      onEffortChange={(effort) => updateStage(index, { effort: effort || "" })}
+                      onFastServiceChange={(fastService) => updateStage(index, { fast_service: fastService || "" })}
+                    />
+                  ) : null}
                   <StageOptionsMenu
                     isAgent={isAgent}
                     autoAdvance={snapshot.auto_advance === true}
@@ -812,32 +836,18 @@ function RoleAgentSwitch({
   role,
   disabled,
   agent,
-  model,
-  mode,
-  effort,
-  fastService,
   agents,
   onUserClick,
   onAgentActivate,
   onAgentChange,
-  onModeChange,
-  onEffortChange,
-  onFastServiceChange,
 }: {
   role: "user" | "agent";
   disabled?: boolean;
   agent: string;
-  model: string;
-  mode: string;
-  effort: string;
-  fastService: "" | "on" | "off";
   agents: AgentStatus[];
   onUserClick: () => void;
   onAgentActivate: () => void;
-  onAgentChange: (agent: string, model?: string) => void;
-  onModeChange: (mode?: string) => void;
-  onEffortChange: (effort?: string) => void;
-  onFastServiceChange: (fastService?: "" | "on" | "off") => void;
+  onAgentChange: (agent: string) => void;
 }) {
   const userActive = role === "user";
   return (
@@ -878,18 +888,11 @@ function RoleAgentSwitch({
         >
           <AgentSelector
             agent={agent}
-            model={model}
-            mode={mode}
-            effort={effort}
-            fastService={fastService}
             agents={agents}
             compact
             menuPlacement="bottom"
             showChevron
             onAgentChange={onAgentChange}
-            onModeChange={onModeChange}
-            onEffortChange={onEffortChange}
-            onFastServiceChange={onFastServiceChange}
           />
         </div>
       ) : (

--- a/web/src/services/agents.ts
+++ b/web/src/services/agents.ts
@@ -35,6 +35,8 @@ export type AgentModelInfo = {
   description?: string;
   hidden?: boolean;
   supportEffort?: boolean;
+  efforts?: string[];
+  default_effort?: string;
 };
 
 export type AgentModeInfo = {
@@ -59,7 +61,6 @@ export type ShellStatus = {
   default?: boolean;
 };
 
-const VALID_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
 function normalizeEfforts(input: unknown): string[] | undefined {
   if (!Array.isArray(input)) {
     return undefined;
@@ -67,8 +68,12 @@ function normalizeEfforts(input: unknown): string[] | undefined {
   const seen = new Set<string>();
   const efforts: string[] = [];
   for (const item of input) {
-    const value = String(item || "").trim().toLowerCase();
-    if (!VALID_EFFORTS.includes(value as (typeof VALID_EFFORTS)[number])) {
+    if (typeof item !== "string") {
+      continue;
+    }
+    const value = item.trim().toLowerCase();
+    // 思考等级由 Agent 的模型目录定义，不能用前端白名单丢弃 ultra 等新增能力。
+    if (!value) {
       continue;
     }
     if (seen.has(value)) {
@@ -88,6 +93,16 @@ function normalizeAgentStatus(input: unknown): AgentStatus | null {
   return {
     ...agent,
     efforts: normalizeEfforts(agent.efforts),
+    models: Array.isArray(agent.models)
+      ? agent.models.map((model) => ({
+          ...model,
+          efforts: normalizeEfforts(model.efforts),
+          default_effort:
+            typeof model.default_effort === "string"
+              ? model.default_effort.trim().toLowerCase()
+              : "",
+        }))
+      : agent.models,
     default_fast_service:
       typeof agent.default_fast_service === "string"
         ? agent.default_fast_service


### PR DESCRIPTION
**服务端**
- `codex/session.go:ListModels` — 设置 `IncludeHidden=true`，使 `gpt-5.6-sol` 等隐藏模型可在前端选择
- `codex/session.go:mapCodexModel` — 新增，将 app-server 返回的 `SupportedReasoningEfforts`/`DefaultReasoningEffort` 透传到 `ModelInfo`， 确保每个模型的思考等级列表和默认值独立展示（如 ultramax/xhigh/high/medium/low）
- `types/types.go:ModelInfo` — 增加 `Efforts []string` 和 `DefaultEffort string` 字段
- `probe.go:inferAgentEfforts` — 优先使用模型级 `Efforts`，无声明时保 CFD 回退

**前端**
- `AgentSelector.tsx` — 剥离模型/模式/思考等级/Fast 配置，仅保留 Agent 列表、 错误查看和重启功能；`onAgentChange` 签名简化，不再传递 model
- `ModelSelector.tsx`（新增） — 独立选择器，接管模型选择、模式、思考等级和 Fast 配置；切换模型时自动重置思考等级为模型默认值
- `ActionBar.tsx` / `ScheduledAgentTaskDialog.tsx` / `TaskTemplateDialog.tsx` — 三个入口同步拆分，Agent 和 Model 选择器相邻并排
- `agents.ts` — 补齐 `ModelInfo` 类型中 `efforts` / `default_effort` 字段声明