### PR TITLE
fix: 修复最终回复复制和用户消息时间

### DIFF
--- a/server/internal/api/appcontext.go
+++ b/server/internal/api/appcontext.go
@@ -277,8 +277,8 @@ func (s *AppContext) RunAgentStage(ctx context.Context, exec kanban.AgentStageEx
 		FastService:     normalizeFastServiceValue(exec.Stage.FastService),
 		PlanMode:        &planMode,
 		Content:         exec.Prompt,
-		OnStart: func() {
-			s.BroadcastSessionUserMessage(exec.RootID, sessionKey, session.TypeChat, sessionName, exec.Stage.Agent, exec.Stage.Model, exec.Stage.Mode, exec.Stage.Effort, exec.Stage.FastService, planMode, exec.Prompt)
+		OnStart: func(userTimestamp time.Time) {
+			s.BroadcastSessionUserMessage(exec.RootID, sessionKey, session.TypeChat, sessionName, exec.Stage.Agent, exec.Stage.Model, exec.Stage.Mode, exec.Stage.Effort, exec.Stage.FastService, planMode, exec.Prompt, userTimestamp)
 		},
 		OnUpdate: func(update agenttypes.Event) {
 			updateTracker.Begin()
@@ -733,9 +733,9 @@ func (s *AppContext) SetSessionPendingReply(rootID, sessionKey, sessionTitle str
 	s.GetSessionStreamHub().SetPendingReply(rootID, sessionKey, sessionTitle)
 }
 
-func (s *AppContext) BroadcastSessionUserMessage(rootID, sessionKey, sessionType, sessionName, agentName, model, mode, effort, fastService string, planMode bool, content string) {
+func (s *AppContext) BroadcastSessionUserMessage(rootID, sessionKey, sessionType, sessionName, agentName, model, mode, effort, fastService string, planMode bool, content string, timestamp time.Time) {
 	s.ClearTaskAuxFlagsForSession(rootID, sessionKey)
-	s.GetSessionStreamHub().BroadcastSessionUserMessage(rootID, sessionKey, sessionType, sessionName, agentName, model, mode, effort, fastService, planMode, content, "", false)
+	s.GetSessionStreamHub().BroadcastSessionUserMessage(rootID, sessionKey, sessionType, sessionName, agentName, model, mode, effort, fastService, planMode, content, timestamp, "", false)
 }
 
 func (s *AppContext) BroadcastSessionUpdate(rootID, sessionKey string, update agenttypes.Event) {

--- a/server/internal/api/stream_hub.go
+++ b/server/internal/api/stream_hub.go
@@ -346,9 +346,13 @@ func (h *StreamHub) getAllClientIDs() []string {
 	return clientIDs
 }
 
-func (h *StreamHub) SetPendingUser(rootID, sessionKey, sessionTitle, agent, model, mode, effort, fastService string, planMode bool, content string) *PendingUserMessage {
+func (h *StreamHub) SetPendingUser(rootID, sessionKey, sessionTitle, agent, model, mode, effort, fastService string, planMode bool, content string, timestamp time.Time) *PendingUserMessage {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	timestamp = timestamp.UTC()
+	if timestamp.IsZero() {
+		timestamp = time.Now().UTC()
+	}
 	state := h.ensurePendingSessionLocked(sessionKey)
 	delete(h.completed, sessionKey)
 	state.RootID = rootID
@@ -362,7 +366,7 @@ func (h *StreamHub) SetPendingUser(rootID, sessionKey, sessionTitle, agent, mode
 		FastService: fastService,
 		PlanMode:    planMode,
 		Content:     content,
-		Timestamp:   time.Now().UTC(),
+		Timestamp:   timestamp,
 	}
 	state.ReplyingList = nil
 	state.Summary = ""
@@ -812,10 +816,11 @@ func (h *StreamHub) BroadcastSessionUserMessage(
 	fastService string,
 	planMode bool,
 	content string,
+	timestamp time.Time,
 	excludeClientID string,
 	queued bool,
 ) {
-	pendingUser := h.SetPendingUser(rootID, sessionKey, sessionName, agentName, model, mode, effort, fastService, planMode, content)
+	pendingUser := h.SetPendingUser(rootID, sessionKey, sessionName, agentName, model, mode, effort, fastService, planMode, content, timestamp)
 	resp := buildSessionUserMessageResponse(rootID, sessionKey, sessionType, sessionName, agentName, model, mode, effort, fastService, planMode, content, pendingUser.Timestamp, queued)
 	for _, clientID := range h.GetSessionClientIDs(sessionKey, false) {
 		if clientID == excludeClientID {

--- a/server/internal/api/usecase/session.go
+++ b/server/internal/api/usecase/session.go
@@ -1045,8 +1045,9 @@ type SendMessageInput struct {
 	Shell                  string
 	TerminalCols           int
 	Content                string
+	UserTimestamp          time.Time
 	ClientCtx              ClientContext
-	OnStart                func()
+	OnStart                func(time.Time)
 	OnUpdate               func(agenttypes.Event)
 	OnSubSessionCreated    func(*session.Session)
 	OnSubSessionUpdate     func(sessionKey string, update agenttypes.Event)
@@ -1926,6 +1927,11 @@ func (s *Service) SendMessage(ctx context.Context, in SendMessageInput) error {
 	if err := s.ensureRegistry(); err != nil {
 		return err
 	}
+	userTimestamp := in.UserTimestamp.UTC()
+	if userTimestamp.IsZero() {
+		userTimestamp = time.Now().UTC()
+	}
+	in.UserTimestamp = userTimestamp
 	sendLock := getSessionSendLock(in.Key)
 	sendLock.Lock()
 	defer sendLock.Unlock()
@@ -1933,7 +1939,7 @@ func (s *Service) SendMessage(ctx context.Context, in SendMessageInput) error {
 	registerActiveTurn(in.RootID, in.Key, turnCancel)
 	defer unregisterActiveTurn(in.RootID, in.Key)
 	if in.OnStart != nil {
-		in.OnStart()
+		in.OnStart(userTimestamp)
 	}
 	manager, err := s.Registry.GetSessionManager(in.RootID)
 	if err != nil {
@@ -2207,7 +2213,7 @@ func (s *Service) SendMessage(ctx context.Context, in SendMessageInput) error {
 	resolvedMode := resolveRuntimeMode(current, in.Mode)
 	modelDisplayName := s.resolveExchangeModelDisplayName(in.Agent, resolvedModel)
 	exchangeCtx := session.WithExchangeModelDisplayName(ctx, modelDisplayName)
-	if err := manager.AddExchangeForAgent(exchangeCtx, current, "user", in.Content, in.Agent, resolvedMode, resolvedEffort, resolvedFastService); err != nil {
+	if err := manager.AddExchangeForAgentAt(exchangeCtx, current, "user", in.Content, in.Agent, resolvedMode, resolvedEffort, resolvedFastService, userTimestamp); err != nil {
 		log.Printf("[session] persist.user.error root=%s session=%s agent=%s err=%v", in.RootID, current.Key, in.Agent, err)
 		return err
 	}
@@ -2966,7 +2972,7 @@ func (s *Service) sendCommandMessage(ctx context.Context, in SendMessageInput, m
 			in.OnUpdate(agenttypes.Event{Type: agenttypes.EventTypeToolUpdate, Data: final})
 			in.OnUpdate(agenttypes.Event{Type: agenttypes.EventTypeMessageDone, Data: agenttypes.MessageDone{}})
 		}
-		if persistErr := persistCommandTurn(ctx, manager, current, in.Content, final, plannedAssistantSeq); persistErr != nil {
+		if persistErr := persistCommandTurn(ctx, manager, current, in.Content, final, plannedAssistantSeq, in.UserTimestamp); persistErr != nil {
 			return persistErr
 		}
 		return err
@@ -3048,7 +3054,7 @@ func (s *Service) sendCommandMessage(ctx context.Context, in SendMessageInput, m
 		in.OnUpdate(agenttypes.Event{Type: agenttypes.EventTypeToolUpdate, Data: final})
 		in.OnUpdate(agenttypes.Event{Type: agenttypes.EventTypeMessageDone, Data: agenttypes.MessageDone{}})
 	}
-	if err := persistCommandTurn(context.Background(), manager, current, in.Content, final, plannedAssistantSeq); err != nil {
+	if err := persistCommandTurn(context.Background(), manager, current, in.Content, final, plannedAssistantSeq, in.UserTimestamp); err != nil {
 		log.Printf("[command] persist.error root=%s session=%s call=%s err=%v", in.RootID, current.Key, callID, err)
 		return err
 	}
@@ -3141,8 +3147,8 @@ func configuredShells(registry Registry) []commandexec.ShellSpec {
 	return shells
 }
 
-func persistCommandTurn(ctx context.Context, manager *session.Manager, current *session.Session, command string, final agenttypes.ToolCall, plannedAssistantSeq int) error {
-	if err := manager.AddExchangeForAgent(ctx, current, "user", command, "", "", "", ""); err != nil {
+func persistCommandTurn(ctx context.Context, manager *session.Manager, current *session.Session, command string, final agenttypes.ToolCall, plannedAssistantSeq int, userTimestamp time.Time) error {
+	if err := manager.AddExchangeForAgentAt(ctx, current, "user", command, "", "", "", "", userTimestamp); err != nil {
 		return err
 	}
 	if err := manager.AddExchangeForAgent(ctx, current, "agent", "", "", "", "", ""); err != nil {

--- a/server/internal/api/usecase/usecase_test.go
+++ b/server/internal/api/usecase/usecase_test.go
@@ -213,11 +213,17 @@ func TestSendCommandMessagePersistsFinalToolCallAndSuggestion(t *testing.T) {
 		t.Fatalf("create command session: %v", err)
 	}
 
+	userTimestamp := time.Date(2026, 7, 26, 3, 4, 5, 6000000, time.UTC)
+	var startedAt time.Time
 	var sawStart, sawFinal, sawDone bool
 	err = service.SendMessage(context.Background(), SendMessageInput{
-		RootID:  root.ID,
-		Key:     created.Key,
-		Content: "printf mindfs-command",
+		RootID:        root.ID,
+		Key:           created.Key,
+		Content:       "printf mindfs-command",
+		UserTimestamp: userTimestamp,
+		OnStart: func(timestamp time.Time) {
+			startedAt = timestamp
+		},
 		OnUpdate: func(event agenttypes.Event) {
 			if event.Type == agenttypes.EventTypeMessageDone {
 				sawDone = true
@@ -250,6 +256,9 @@ func TestSendCommandMessagePersistsFinalToolCallAndSuggestion(t *testing.T) {
 	if !sawStart || !sawFinal || !sawDone {
 		t.Fatalf("events sawStart=%v sawFinal=%v sawDone=%v", sawStart, sawFinal, sawDone)
 	}
+	if !startedAt.Equal(userTimestamp) {
+		t.Fatalf("OnStart timestamp = %s, want %s", startedAt, userTimestamp)
+	}
 
 	current, err := manager.Get(context.Background(), created.Key, 0)
 	if err != nil {
@@ -257,6 +266,9 @@ func TestSendCommandMessagePersistsFinalToolCallAndSuggestion(t *testing.T) {
 	}
 	if len(current.Exchanges) != 2 {
 		t.Fatalf("exchange count = %d, want 2", len(current.Exchanges))
+	}
+	if !current.Exchanges[0].Timestamp.Equal(userTimestamp) {
+		t.Fatalf("user exchange timestamp = %s, want %s", current.Exchanges[0].Timestamp, userTimestamp)
 	}
 	aux, err := manager.GetExchangeAux(context.Background(), created.Key, 0)
 	if err != nil {

--- a/server/internal/api/ws.go
+++ b/server/internal/api/ws.go
@@ -568,9 +568,12 @@ func (h *WSHandler) handleSessionMessage(ctx context.Context, conn *websocket.Co
 
 	uc := &usecase.Service{Registry: h.AppContext}
 	streamHub := h.AppContext.GetSessionStreamHub()
+	userTimestamp := time.Now().UTC()
 	if requestID != "" {
-		if !h.reserveClientRequest(requestID) {
-			h.sendWSAccepted(conn, clientID, requestID, rootID, key)
+		reservedAt, reserved := h.reserveClientRequest(requestID)
+		userTimestamp = reservedAt
+		if !reserved {
+			h.sendWSAcceptedAt(conn, clientID, requestID, rootID, key, userTimestamp)
 			return
 		}
 	}
@@ -639,7 +642,7 @@ func (h *WSHandler) handleSessionMessage(ctx context.Context, conn *websocket.Co
 		}
 	}
 	if requestID != "" {
-		h.sendWSAccepted(conn, clientID, requestID, rootID, key)
+		h.sendWSAcceptedAt(conn, clientID, requestID, rootID, key, userTimestamp)
 	}
 	if h.AppContext != nil {
 		streamHub.BindSessionClient(key, clientID)
@@ -653,7 +656,7 @@ func (h *WSHandler) handleSessionMessage(ctx context.Context, conn *websocket.Co
 		FastService: fastService,
 		PlanMode:    planMode,
 		Content:     content,
-		Timestamp:   time.Now().UTC(),
+		Timestamp:   userTimestamp,
 	}
 	job := sessionMessageJob{
 		RootID:          rootID,
@@ -710,7 +713,8 @@ func (h *WSHandler) handleSessionSlashCommandRun(ctx context.Context, conn *webs
 		return
 	}
 	if requestID != "" {
-		if !h.reserveClientRequest(requestID) {
+		_, reserved := h.reserveClientRequest(requestID)
+		if !reserved {
 			h.sendWSAccepted(conn, clientID, requestID, rootID, key)
 			return
 		}
@@ -845,21 +849,22 @@ func (h *WSHandler) runSessionMessage(job sessionMessageJob) {
 	}
 
 	err := uc.SendMessage(msgCtx, usecase.SendMessageInput{
-		RootID:       rootID,
-		Key:          key,
-		Agent:        job.User.Agent,
-		Model:        job.User.Model,
-		Mode:         job.User.Mode,
-		Effort:       job.User.Effort,
-		FastService:  job.User.FastService,
-		PlanMode:     &job.User.PlanMode,
-		Shell:        job.Shell,
-		TerminalCols: job.TerminalCols,
-		Content:      job.User.Content,
-		ClientCtx:    job.ClientCtx,
-		OnStart: func() {
+		RootID:        rootID,
+		Key:           key,
+		Agent:         job.User.Agent,
+		Model:         job.User.Model,
+		Mode:          job.User.Mode,
+		Effort:        job.User.Effort,
+		FastService:   job.User.FastService,
+		PlanMode:      &job.User.PlanMode,
+		Shell:         job.Shell,
+		TerminalCols:  job.TerminalCols,
+		Content:       job.User.Content,
+		UserTimestamp: job.User.Timestamp,
+		ClientCtx:     job.ClientCtx,
+		OnStart: func(userTimestamp time.Time) {
 			h.AppContext.ClearTaskAuxFlagsForSession(rootID, key)
-			streamHub.BroadcastSessionUserMessage(rootID, key, job.SessionType, job.SessionName, job.User.Agent, job.User.Model, job.User.Mode, job.User.Effort, job.User.FastService, job.User.PlanMode, job.User.Content, job.ExcludeClientID, job.Queued)
+			streamHub.BroadcastSessionUserMessage(rootID, key, job.SessionType, job.SessionName, job.User.Agent, job.User.Model, job.User.Mode, job.User.Effort, job.User.FastService, job.User.PlanMode, job.User.Content, userTimestamp, job.ExcludeClientID, job.Queued)
 		},
 		OnUpdate: func(update agenttypes.Event) {
 			updateTracker.Begin()
@@ -1080,22 +1085,31 @@ func (h *WSHandler) sendE2EEError(conn *websocket.Conn, id, code string) {
 }
 
 func (h *WSHandler) sendWSAccepted(conn *websocket.Conn, clientID, requestID, rootID, sessionKey string) {
+	h.sendWSAcceptedAt(conn, clientID, requestID, rootID, sessionKey, time.Time{})
+}
+
+func (h *WSHandler) sendWSAcceptedAt(conn *websocket.Conn, clientID, requestID, rootID, sessionKey string, timestamp time.Time) {
+	payload := map[string]any{
+		"request_id":  requestID,
+		"root_id":     rootID,
+		"session_key": sessionKey,
+	}
+	if !timestamp.IsZero() {
+		payload["timestamp"] = timestamp.UTC()
+	}
 	resp := WSResponse{
-		ID:   requestID,
-		Type: "session.accepted",
-		Payload: map[string]any{
-			"request_id":  requestID,
-			"root_id":     rootID,
-			"session_key": sessionKey,
-		},
+		ID:      requestID,
+		Type:    "session.accepted",
+		Payload: payload,
 	}
 	_ = h.writeWSJSON(clientID, conn, resp)
 }
 
-func (h *WSHandler) reserveClientRequest(requestID string) bool {
+func (h *WSHandler) reserveClientRequest(requestID string) (time.Time, bool) {
 	requestID = strings.TrimSpace(requestID)
+	now := time.Now().UTC()
 	if requestID == "" {
-		return true
+		return now, true
 	}
 	h.requestMu.Lock()
 	defer h.requestMu.Unlock()
@@ -1108,11 +1122,11 @@ func (h *WSHandler) reserveClientRequest(requestID string) bool {
 			delete(h.requests, id)
 		}
 	}
-	if _, exists := h.requests[requestID]; exists {
-		return false
+	if seenAt, exists := h.requests[requestID]; exists {
+		return seenAt, false
 	}
-	h.requests[requestID] = time.Now().UTC()
-	return true
+	h.requests[requestID] = now
+	return now, true
 }
 
 func (h *WSHandler) writeWSJSON(clientID string, conn *websocket.Conn, resp WSResponse) error {

--- a/server/internal/api/ws_test.go
+++ b/server/internal/api/ws_test.go
@@ -41,6 +41,46 @@ func TestParseClientContext(t *testing.T) {
 	}
 }
 
+func TestReserveClientRequestKeepsOriginalTimestamp(t *testing.T) {
+	handler := &WSHandler{}
+
+	firstTimestamp, firstReserved := handler.reserveClientRequest("request-1")
+	secondTimestamp, secondReserved := handler.reserveClientRequest("request-1")
+
+	if !firstReserved {
+		t.Fatal("first request was not reserved")
+	}
+	if secondReserved {
+		t.Fatal("duplicate request was reserved again")
+	}
+	if !secondTimestamp.Equal(firstTimestamp) {
+		t.Fatalf("duplicate timestamp = %s, want %s", secondTimestamp, firstTimestamp)
+	}
+}
+
+func TestStreamHubPendingUserKeepsProvidedTimestamp(t *testing.T) {
+	hub := NewStreamHub(nil)
+	want := time.Date(2026, 7, 26, 3, 4, 5, 6000000, time.UTC)
+
+	pending := hub.SetPendingUser(
+		"root",
+		"session",
+		"Session",
+		"codex",
+		"gpt-5",
+		"default",
+		"high",
+		"off",
+		false,
+		"prompt",
+		want,
+	)
+
+	if !pending.Timestamp.Equal(want) {
+		t.Fatalf("pending timestamp = %s, want %s", pending.Timestamp, want)
+	}
+}
+
 func TestAppendReplyEventPrefixesTruncatedSummary(t *testing.T) {
 	hub := NewStreamHub(nil)
 

--- a/server/internal/scheduled/tasks.go
+++ b/server/internal/scheduled/tasks.go
@@ -27,7 +27,7 @@ const tasksMetaFile = "scheduled-agent-tasks.json"
 type SessionActivityBroadcaster interface {
 	BroadcastSessionMetaUpdated(rootID string, sess *session.Session)
 	SetSessionPendingReply(rootID, sessionKey, sessionTitle string)
-	BroadcastSessionUserMessage(rootID, sessionKey, sessionType, sessionName, agentName, model, mode, effort, fastService string, planMode bool, content string)
+	BroadcastSessionUserMessage(rootID, sessionKey, sessionType, sessionName, agentName, model, mode, effort, fastService string, planMode bool, content string, timestamp time.Time)
 	BroadcastSessionUpdate(rootID, sessionKey string, update agenttypes.Event)
 	BroadcastSessionError(rootID, sessionKey, message string)
 	BroadcastSessionDone(rootID, sessionKey, requestID string)
@@ -490,8 +490,8 @@ func (s *Service) runTask(ctx context.Context, task Task, force bool) error {
 		ClientCtx: usecase.ClientContext{
 			CurrentRoot: current.RootID,
 		},
-		OnStart: func() {
-			broadcaster.BroadcastSessionUserMessage(current.RootID, sessionKey, session.TypeChat, sessionName, current.Agent, current.Model, current.Mode, current.Effort, current.FastService, false, current.Prompt)
+		OnStart: func(userTimestamp time.Time) {
+			broadcaster.BroadcastSessionUserMessage(current.RootID, sessionKey, session.TypeChat, sessionName, current.Agent, current.Model, current.Mode, current.Effort, current.FastService, false, current.Prompt, userTimestamp)
 		},
 		OnUpdate: func(update agenttypes.Event) {
 			broadcaster.BroadcastSessionUpdate(current.RootID, sessionKey, update)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9445,12 +9445,18 @@ export function App({ onGoHome }: AppProps) {
           }
           console.info("[session/ws] accepted", { requestId, rootId: pending.rootId, sessionKey: pending.sessionKey || null, tempKey: pending.tempKey || null });
           delete pendingRequestRef.current[requestId];
+          const acceptedTimestamp =
+            typeof payload?.timestamp === "string" &&
+            !Number.isNaN(Date.parse(payload.timestamp))
+              ? payload.timestamp
+              : pending.timestamp;
           const acceptedSessionKey =
             typeof payload?.session_key === "string" ? payload.session_key : "";
           if (!pending.sessionKey && pending.tempKey && acceptedSessionKey) {
             const cacheKey = rootSessionKey(pending.rootId, acceptedSessionKey);
             pendingBySessionRef.current[cacheKey] = {
               ...pending,
+              timestamp: acceptedTimestamp,
               sessionKey: acceptedSessionKey,
             };
             setMultiProjectSessionPending(pending.rootId, pending.tempKey, false);
@@ -9474,11 +9480,19 @@ export function App({ onGoHome }: AppProps) {
                   exchange.pending_ack === true &&
                   exchange.content === pending.message &&
                   exchange.timestamp === pending.timestamp
-                    ? { ...exchange, pending_ack: false }
+                    ? {
+                        ...exchange,
+                        timestamp: acceptedTimestamp,
+                        pending_ack: false,
+                      }
                     : exchange,
                 )
               : [];
-            return { ...(sess as any), exchanges } as Session;
+            return {
+              ...(sess as any),
+              exchanges,
+              updated_at: acceptedTimestamp,
+            } as Session;
           };
           const acceptedTargetKey = pending.sessionKey || acceptedSessionKey;
           if (acceptedTargetKey) {

--- a/web/src/components/SessionViewer.tsx
+++ b/web/src/components/SessionViewer.tsx
@@ -955,35 +955,6 @@ function timelineItemSpacing(
   return "16px";
 }
 
-function collectAssistantFlowMarkdown(
-  timeline: TimelineItem[],
-  startIndex: number,
-): string {
-  const segments: string[] = [];
-
-  for (let index = startIndex; index >= 0; index -= 1) {
-    const item = timeline[index];
-    if (item.type === "user_text") {
-      break;
-    }
-    if (item.type === "assistant_text" && item.content) {
-      segments.unshift(item.content);
-    }
-  }
-
-  for (let index = startIndex + 1; index < timeline.length; index += 1) {
-    const item = timeline[index];
-    if (item.type === "user_text") {
-      break;
-    }
-    if (item.type === "assistant_text" && item.content) {
-      segments.push(item.content);
-    }
-  }
-
-  return segments.join("").trim();
-}
-
 function shouldDefaultCollapseRelatedFiles(
   isMobile: boolean,
   relatedFileCount: number,
@@ -1720,9 +1691,7 @@ if (useInnerScrollContainer && !container) {
     const userMessageWidth =
       imageAttachments.length > 0 ? "min(320px, 100%)" : "auto";
     const hasRichUserAttachments = imageAttachments.length > 0;
-    const assistantMarkdownContent = !isUser
-      ? collectAssistantFlowMarkdown(timeline, idx)
-      : "";
+    const assistantMarkdownContent = !isUser ? (item.content || "").trim() : "";
     const assistantExchangeMeta = !isUser
       ? formatAssistantExchangeMeta(item, agents)
       : "";


### PR DESCRIPTION
## 摘要

- 修复 Agent 步骤较多时，复制最终回复会混入中间步骤内容的问题；现在复制按钮仅复制当前最终回复文本。
- 修复移动端用户指令时间受设备本地时钟影响的问题；统一采用服务端接收请求的 UTC 时间，并同步用于 WebSocket 确认、实时广播和会话持久化。
- 重复请求继续复用首次接收时间，避免重试造成消息时间变化。

## 文件改动

- Web 会话展示
  - 移除跨多个助手消息片段拼接复制内容的逻辑。
  - 最终回复的复制操作仅使用当前助手文本块。

- Web 消息状态
  - 接收 `session.accepted` 后，使用服务端返回的时间修正乐观消息及会话更新时间。
  - 服务端未返回有效时间时保留原有客户端时间作为兼容回退。

- 服务端消息链路
  - 在请求进入 WebSocket 时生成并保留用户消息时间。
  - 将同一时间贯穿请求确认、消息广播、待处理状态和会话持久化。
  - Agent 阶段、定时任务和命令会话统一适配新的时间传递方式。
  - 重复 `request_id` 返回首次请求的接收时间。

- 测试
  - 增加重复请求时间保持一致的覆盖。
  - 增加待处理消息保留指定时间的覆盖。
  - 补充命令消息回调及持久化时间一致性断言。

## 自查清单

- [x] `yarn --cwd web typecheck`
- [x] `yarn --cwd web build`
- [x] `go test ./server/internal/...`
- [x] `go test ./...`
- [x] `go test -race ./server/internal/api/...`
- [x] 独立 Reviewer 审查当前分支相对 `main` 的全部提交，未发现 P0–P3 问题
- [x] 工作区干净，无未提交改动