### PR TITLE
feat: add Atlas Cloud API provider preset

### DIFF
--- a/web/src/components/FileTree.tsx
+++ b/web/src/components/FileTree.tsx
@@ -177,6 +177,14 @@ type AgentConfigAddTab = "backup" | "api";
 type AgentConfigSwitchTab = "backup" | "api_provider";
 type AgentConfigSwitchSelection = { type: "backup" | "api_provider"; id: string };
 
+const AGENT_API_PROVIDER_PRESETS = [
+  {
+    id: "atlas-cloud",
+    name: "Atlas Cloud",
+    baseURL: "https://api.atlascloud.ai/v1",
+  },
+] as const;
+
 function isAgentConfigBackupConflict(error: unknown): boolean {
   const maybeError = error as { status?: unknown; message?: unknown; payload?: { error?: unknown; message?: unknown } } | null;
   if (!maybeError) {
@@ -779,6 +787,32 @@ function AgentConfigPopover({
             </>
           ) : (
             <>
+              <div style={agentConfigFieldStyle}>
+                <label style={agentConfigLabelStyle}>{t("agentConfig.providerPreset")}</label>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: "6px" }}>
+                  {AGENT_API_PROVIDER_PRESETS.map((preset) => {
+                    const active = apiProviderName === preset.name && apiProviderBaseURL === preset.baseURL;
+                    return (
+                      <button
+                        key={preset.id}
+                        type="button"
+                        disabled={busy}
+                        onClick={() => {
+                          onAPIProviderNameChange(preset.name);
+                          onAPIProviderBaseURLChange(preset.baseURL);
+                        }}
+                        style={{
+                          ...agentConfigSecondaryButtonStyle(busy),
+                          background: active ? "var(--selection-bg)" : "transparent",
+                          color: active ? "var(--accent-color)" : "var(--text-secondary)",
+                        }}
+                      >
+                        {preset.name}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
               <div style={agentConfigFieldStyle}>
                 <label style={agentConfigLabelStyle}>{t("agentConfig.providerName")}</label>
                 <input

--- a/web/src/i18n/locales/en-US.ts
+++ b/web/src/i18n/locales/en-US.ts
@@ -94,6 +94,7 @@ export const enUS = {
   "agentConfig.env": "Environment variables",
   "agentConfig.envPlaceholder": "KEY=value, one per line",
   "agentConfig.providerName": "Provider name",
+  "agentConfig.providerPreset": "Provider preset",
   "agentConfig.validateAndSave": "Validate and save",
   "agentConfig.noSwitchableConfig": "No switchable configs",
   "agentConfig.noBackups": "No config backups",

--- a/web/src/i18n/locales/zh-CN.ts
+++ b/web/src/i18n/locales/zh-CN.ts
@@ -92,6 +92,7 @@ export const zhCN = {
   "agentConfig.env": "环境变量",
   "agentConfig.envPlaceholder": "KEY=value，每行一个",
   "agentConfig.providerName": "供应商名称",
+  "agentConfig.providerPreset": "供应商预设",
   "agentConfig.validateAndSave": "校验并保存",
   "agentConfig.noSwitchableConfig": "暂无可切换配置",
   "agentConfig.noBackups": "暂无配置备份",


### PR DESCRIPTION
## Summary
- add Atlas Cloud as a selectable API provider preset
- prefill the provider name and OpenAI-compatible base URL while leaving the API key user-supplied
- localize the preset field label in English and Simplified Chinese

## Testing
- `npm run typecheck`
- `NODE_OPTIONS=--max-old-space-size=1536 npm run build`
- verified `https://api.atlascloud.ai/v1/models` returns a live model catalog

No README, logo, sponsor, credits, or partner-promotion changes.