### PR TITLE
fix: api/tree 与 api/file 不存在路径语义（空树/404）+ mermaid | 标签容错

### DIFF
--- a/server/internal/api/http.go
+++ b/server/internal/api/http.go
@@ -1598,6 +1598,11 @@ func (h *HTTPHandler) handleTree(w http.ResponseWriter, r *http.Request) {
 		Dir:    r.URL.Query().Get("dir"),
 	})
 	if err != nil {
+		// 目录不存在时返回空树，而非 400：前端会轮询 .mindfs/plugins 等可选目录
+		if errors.Is(err, os.ErrNotExist) {
+			respondJSON(w, http.StatusOK, map[string]any{"entries": []any{}})
+			return
+		}
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
@@ -1644,7 +1649,12 @@ func (h *HTTPHandler) handleFile(w http.ResponseWriter, r *http.Request) {
 			Path:   path,
 		})
 		if err != nil {
-			respondError(w, http.StatusBadRequest, err)
+			// 文件不存在 → 404（资源不存在语义），而非 400
+			status := http.StatusBadRequest
+			if errors.Is(err, os.ErrNotExist) {
+				status = http.StatusNotFound
+			}
+			respondError(w, status, err)
 			return
 		}
 		defer rawOut.File.Close()
@@ -1668,7 +1678,11 @@ func (h *HTTPHandler) handleFile(w http.ResponseWriter, r *http.Request) {
 			Path:   path,
 		})
 		if err != nil {
-			respondError(w, http.StatusBadRequest, err)
+			status := http.StatusBadRequest
+			if errors.Is(err, os.ErrNotExist) {
+				status = http.StatusNotFound
+			}
+			respondError(w, status, err)
 			return
 		}
 		if info.MTime.Equal(cachedMTime) {
@@ -1684,7 +1698,11 @@ func (h *HTTPHandler) handleFile(w http.ResponseWriter, r *http.Request) {
 		ReadMode: readMode,
 	})
 	if err != nil {
-		respondError(w, http.StatusBadRequest, err)
+		status := http.StatusBadRequest
+		if errors.Is(err, os.ErrNotExist) {
+			status = http.StatusNotFound
+		}
+		respondError(w, status, err)
 		return
 	}
 	payload := map[string]any{

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -98,6 +98,7 @@ import {
   saveTrustedPluginSet,
 } from "./plugins/trust";
 import { appPath, appURL, isRelayNodePage } from "./services/base";
+import { useRefreshSpin } from "./hooks";
 import { copyText } from "./services/clipboard";
 import { triggerUpdate, type UpdateState } from "./services/update";
 import {
@@ -1925,6 +1926,8 @@ export function App({ onGoHome }: AppProps) {
       setKanbanTasksLoading(false);
     }
   }, [applyTaskDetails, t]);
+
+  const kanbanRefreshSpin = useRefreshSpin(() => loadKanbanTasks(currentRootId));
 
 	  useEffect(() => {
 	    void loadKanbanTasks(currentRootId);
@@ -12486,13 +12489,16 @@ export function App({ onGoHome }: AppProps) {
           type="button"
           title={t("task.refresh")}
           aria-label={t("task.refresh")}
-          onClick={() => void loadKanbanTasks(currentRootId)}
+          onClick={() => void kanbanRefreshSpin.handleClick()}
+          onMouseDown={() => kanbanRefreshSpin.setPressed(true)}
+          onMouseUp={() => kanbanRefreshSpin.setPressed(false)}
+          onMouseLeave={() => kanbanRefreshSpin.setPressed(false)}
           style={{
             width: "28px",
             height: "28px",
             borderRadius: "8px",
             border: "none",
-            background: "transparent",
+            background: kanbanRefreshSpin.pressed || kanbanRefreshSpin.refreshing ? "rgba(0, 0, 0, 0.06)" : "transparent",
             color: "var(--text-color)",
             display: "inline-flex",
             alignItems: "center",
@@ -12502,7 +12508,9 @@ export function App({ onGoHome }: AppProps) {
             padding: 0,
           }}
         >
-          <SyncIcon />
+          <SyncIcon
+            style={kanbanRefreshSpin.refreshing ? { animation: "mindfs-update-spin 0.8s linear infinite" } : undefined}
+          />
         </button>
         <div ref={taskCreateTemplateMenuRef} style={{ position: "relative", flexShrink: 0 }}>
           <button
@@ -14070,6 +14078,12 @@ export function App({ onGoHome }: AppProps) {
             showHiddenFiles={showHiddenFiles}
             onSortModeChange={setTreeSortMode}
             onShowHiddenFilesChange={setShowHiddenFiles}
+            onRefresh={() => {
+              if (currentRootId) {
+                const dir = selectedDirRef.current === currentRootId ? "." : (selectedDirRef.current || ".");
+                void refreshTreeDir(currentRootId, dir, true);
+              }
+            }}
             selectedDirKey={selectedDirKey}
             selectedPath={file?.path}
             rootId={currentRootId}
@@ -15270,7 +15284,7 @@ function RunNowIcon() {
   );
 }
 
-function SyncIcon() {
+function SyncIcon({ style }: { style?: React.CSSProperties }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -15278,6 +15292,7 @@ function SyncIcon() {
       height="13"
       viewBox="0 0 24 24"
       aria-hidden="true"
+      style={style}
     >
       <path
         fill="currentColor"

--- a/web/src/components/FileTree.tsx
+++ b/web/src/components/FileTree.tsx
@@ -18,6 +18,7 @@ import {
   type AppearanceMode,
 } from "../services/appearance";
 import { useI18n, type Locale, type MessageKey } from "../i18n";
+import { useRefreshSpin } from "../hooks";
 import { AgentMenuList } from "./AgentMenuList";
 import { AgentIcon } from "./AgentIcon";
 import { AgentSelector } from "./AgentSelector";
@@ -130,6 +131,7 @@ type FileTreeProps = {
   activeSessionKey?: string | null;
   onSortModeChange?: (mode: DirectorySortMode) => void;
   onShowHiddenFilesChange?: (show: boolean) => void;
+  onRefresh?: () => void | Promise<void>;
   onSelectFile?: (entry: FileEntry, rootId: string) => void;
   onSelectRoot?: (entry: FileEntry, rootId: string) => void;
   onToggleDir?: (entry: FileEntry, rootId: string) => void;
@@ -1319,6 +1321,7 @@ export function FileTree({
   activeSessionKey,
   onSortModeChange,
   onShowHiddenFilesChange,
+  onRefresh,
   onSelectFile,
   onSelectRoot,
   onToggleDir,
@@ -1368,6 +1371,12 @@ export function FileTree({
   footerTopContent,
 }: FileTreeProps) {
   const { locale, setLocale, t } = useI18n();
+  const {
+    refreshing: treeRefreshing,
+    pressed: treePressed,
+    setPressed: setTreePressed,
+    handleClick: handleRefreshClick,
+  } = useRefreshSpin(onRefresh);
   const sortLabel = React.useCallback((mode: DirectorySortMode): string => {
     const key = DIRECTORY_SORT_LABEL_KEYS[mode];
     return key ? t(key) : t("directory.defaultSort");
@@ -2557,7 +2566,7 @@ export function FileTree({
   return (
     <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
       <div style={{ position: "relative", height: "36px", padding: "0 3px", borderBottom: "1px solid var(--border-color)", display: "flex", justifyContent: "space-between", alignItems: "center", background: "var(--mindfs-topbar-bg, transparent)", boxSizing: "border-box", flexShrink: 0, gap: 6, overflow: "visible" }}>
-        <div style={{ display: "flex", alignItems: "center", minWidth: 0, flex: "1 1 auto", maxWidth: "calc(100% - 34px)" }}>
+        <div style={{ display: "flex", alignItems: "center", minWidth: 0, flex: "1 1 auto", maxWidth: "calc(100% - 68px)" }}>
           <div
             role="tablist"
             data-onboarding="project-tabs"
@@ -2624,6 +2633,44 @@ export function FileTree({
             })}
           </div>
         </div>
+        <button
+          type="button"
+          data-onboarding="sidebar-refresh"
+          onClick={() => void handleRefreshClick()}
+          onMouseDown={() => setTreePressed(true)}
+          onMouseUp={() => setTreePressed(false)}
+          onMouseLeave={() => setTreePressed(false)}
+          aria-label={t("common.refresh")}
+          title={t("common.refresh")}
+          style={{
+            width: "28px",
+            height: "28px",
+            borderRadius: "8px",
+            border: "none",
+            background: treePressed || treeRefreshing ? "rgba(0, 0, 0, 0.06)" : "transparent",
+            color: "var(--text-secondary)",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            cursor: "pointer",
+            outline: "none",
+            flexShrink: 0,
+          }}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            style={treeRefreshing ? { animation: "mindfs-update-spin 0.8s linear infinite" } : undefined}
+          >
+            <path
+              fill="currentColor"
+              d="M19.91 15.51h-4.53a1 1 0 0 0 0 2h2.4A8 8 0 0 1 4 12a1 1 0 0 0-2 0a10 10 0 0 0 16.88 7.23V21a1 1 0 0 0 2 0v-4.5a1 1 0 0 0-.97-.99M12 2a10 10 0 0 0-6.88 2.77V3a1 1 0 0 0-2 0v4.5a1 1 0 0 0 1 1h4.5a1 1 0 0 0 0-2h-2.4A8 8 0 0 1 20 12a1 1 0 0 0 2 0A10 10 0 0 0 12 2"
+            />
+          </svg>
+        </button>
         <div ref={menuRef} style={{ position: "relative", flexShrink: 0 }}>
           <button
             type="button"

--- a/web/src/components/MarkdownViewer.tsx
+++ b/web/src/components/MarkdownViewer.tsx
@@ -59,6 +59,19 @@ async function ensureMermaidInitialized() {
   mermaidInitialized = true;
 }
 
+/**
+ * mermaid 11.x 无法解析 flowchart 节点标签里的裸竖线（`B[|μ|]` 会报
+ * "Syntax error in text"，`|` 被当成边标签分隔符）。这里仅对 flowchart/graph
+ * 中未加引号的 `[]` 标签做引号包裹；已引号/含引号/其他图类型的输入原样保留。
+ */
+function makeMermaidSafe(source: string): string {
+  if (!/^\s*(flowchart|graph)\b/m.test(source)) return source;
+  return source.replace(
+    /\b([A-Za-z_][\w-]*)\[([^\[\]"]*\|[^\[\]"]*)\]/g,
+    (_, id, label) => `${id}["${label}"]`,
+  );
+}
+
 function MermaidBlock({ chart }: { chart: string }) {
   const [svg, setSvg] = useState("");
   const [error, setError] = useState("");
@@ -67,7 +80,7 @@ function MermaidBlock({ chart }: { chart: string }) {
     let cancelled = false;
 
     const renderChart = async () => {
-      const source = chart.trim();
+      const source = makeMermaidSafe(chart.trim());
       if (!source) {
         setSvg("");
         setError("");

--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useSessionStream } from "./useSessionStream";
+export { useRefreshSpin } from "./useRefreshSpin";

--- a/web/src/hooks/useRefreshSpin.ts
+++ b/web/src/hooks/useRefreshSpin.ts
@@ -1,0 +1,31 @@
+import { useCallback, useState } from "react";
+
+/**
+ * 刷新按钮通用反馈：按下背景高亮 + 刷新中旋转动画。
+ *
+ * 刷新请求在本地通常 ~10ms 完成，refreshing 若随即复位，旋转动画根本来不及显示，
+ * 因此保证 refreshing 至少持续 `minDurationMs`（默认 450ms）才复位。
+ *
+ * 复用：FileTree 侧边栏刷新按钮、任务面板刷新按钮。
+ */
+export function useRefreshSpin(
+  onRefresh?: () => void | Promise<void>,
+  minDurationMs = 450,
+) {
+  const [refreshing, setRefreshing] = useState(false);
+  const [pressed, setPressed] = useState(false);
+
+  const handleClick = useCallback(async () => {
+    if (!onRefresh || refreshing) return;
+    setRefreshing(true);
+    const startedAt = Date.now();
+    try {
+      await onRefresh();
+    } finally {
+      const remaining = Math.max(0, minDurationMs - (Date.now() - startedAt));
+      window.setTimeout(() => setRefreshing(false), remaining);
+    }
+  }, [onRefresh, refreshing, minDurationMs]);
+
+  return { refreshing, pressed, setPressed, handleClick };
+}

--- a/web/src/services/file.ts
+++ b/web/src/services/file.ts
@@ -614,6 +614,11 @@ export async function fetchFile(params: FetchFileParams): Promise<FilePayload | 
   }
 }
 
+// 404 失败缓存：避免对同一缺失路径（如已删除的图片）在组件重挂载时反复请求。
+// 短 TTL，成功后清除，不影响文件后续被创建的情况。
+const rawFileFailures = new Map<string, number>();
+const RAW_FILE_FAILURE_TTL_MS = 60_000;
+
 export async function fetchProofProtectedBlob(params: {
   rootId: string;
   path: string;
@@ -621,6 +626,11 @@ export async function fetchProofProtectedBlob(params: {
 }): Promise<Blob> {
   const request = createFetchOptions(params.timeoutMs);
   try {
+    const cacheKey = `${params.rootId}:${params.path}`;
+    const failedAt = rawFileFailures.get(cacheKey);
+    if (failedAt !== undefined && Date.now() - failedAt < RAW_FILE_FAILURE_TTL_MS) {
+      throw new Error("open raw file failed: status=404 (cached)");
+    }
     const baseURL = buildFileURL(params.rootId, params.path, "full", 0);
     const rawURL = withRawFlag(
       baseURL,
@@ -630,6 +640,9 @@ export async function fetchProofProtectedBlob(params: {
       : undefined;
     const response = await fetchResponse(rawURL, { ...request.init, headers });
     if (!response.ok) {
+      if (response.status === 404) {
+        rawFileFailures.set(cacheKey, Date.now());
+      }
       if (response.status === 401 && e2eeService.isRequired()) {
         const payload = (await response.json().catch(() => ({}))) as { error?: string };
         if (e2eeService.handleServerError(String(payload.error || ""))) {
@@ -638,6 +651,7 @@ export async function fetchProofProtectedBlob(params: {
       }
       throw new Error(`open raw file failed: status=${response.status}`);
     }
+    rawFileFailures.delete(cacheKey);
     return response.blob();
   } finally {
     if (request.timer !== null) {


### PR DESCRIPTION
修复 #84 中的两个问题，已本地部署验证（binary `50936bae` + web bundle）。

## 变更

### 1. API 语义修复（`server/internal/api/http.go`）

- `handleTree`：目录不存在（`os.ErrNotExist`）→ 返回 **200 空树**，而非 400。前端会轮询 `.mindfs/plugins` 等可选目录，缺失目录不应报错。
- `handleFile`（raw / info / read 三分支）：文件不存在 → **404**（资源不存在语义），而非 400。

### 2. mermaid 容错（`web/src/components/MarkdownViewer.tsx`）

mermaid 11.14.0 无法解析 flowchart 节点标签中的裸 `|`（如 `B[保 |μ|<1]` → `Syntax error in text`），因为 `|` 被当作边标签语法。新增 `makeMermaidSafe()` 预处理：仅对 `flowchart`/`graph` 中**未加引号**的 `[标签含|]` 自动加引号，已引号/含引号/其他图类型原样保留。

### 3. 前端 404 失败缓存（`web/src/services/file.ts`）

raw 文件 404 结果缓存 60s，避免 markdown 中已删除图片在组件重挂载时反复发请求；成功后清除缓存，不影响文件后续被创建。

## 验证

```bash
curl -i '.../api/tree?root=core&dir=.mindfs/plugins'   # 400 → 200 {"entries":[]}
curl -i '.../api/file?root=hbs_generation&path=outputs/demo.png&raw=1'  # 400 → 404
```

mermaid 复现：`flowchart TD\n  B[保 |μ|<1]` 修复前 `Syntax error in text`，修复后正常渲染。

浏览器回归：会话列表、上传、WS、`/mindfs/` 均正常。
