### PR TITLE
fix: external sessions undiscoverable for CJK/space paths (encode project dir names like Claude Code)

### DIFF
--- a/server/internal/agent/claude/importer.go
+++ b/server/internal/agent/claude/importer.go
@@ -528,15 +528,21 @@ func claudeProjectDirName(rootPath string) string {
 	return sanitizeClaudeProjectPath(rootPath)
 }
 
+// sanitizeClaudeProjectPath encodes a cwd path the same way Claude Code does
+// when creating its session folder name under ~/.claude/projects: every
+// character outside [A-Za-z0-9] (spaces, CJK chars, dots, slashes, etc.) is
+// replaced with "-".
 func sanitizeClaudeProjectPath(path string) string {
-	replacer := strings.NewReplacer(
-		"/", "-",
-		"\\", "-",
-		":", "-",
-		".", "-",
-		"_", "-",
-	)
-	return replacer.Replace(path)
+	var b strings.Builder
+	b.Grow(len(path))
+	for _, r := range path {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
 }
 
 func (i *Importer) storeSessionFiles(items []claudeSessionFile) {

--- a/server/internal/agent/claude/importer_test.go
+++ b/server/internal/agent/claude/importer_test.go
@@ -171,3 +171,24 @@ func TestReadClaudeImportedSubagentsLinksAgentToolCall(t *testing.T) {
 		t.Fatalf("len(exchanges) = %d, want 2", len(item.Exchanges))
 	}
 }
+
+func TestClaudeProjectDirNameMatchesClaudeCodeOnDiskEncoding(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"ascii path keeps letters and digits", "/Users/Ye/Databases/L000", "-Users-Ye-Databases-L000"},
+		{"cjk and space chars become dashes", "/Users/Ye/HOBBIES/260817Claude Code远程访问第三方方案", "-Users-Ye-HOBBIES-260817Claude-Code---------"},
+		{"dot becomes dash", "/Users/Ye/.claude", "-Users-Ye--claude"},
+		{"underscore becomes dash", "/a_b/c", "-a-b-c"},
+		{"tailing slash stripped", "/Users/Ye/L000/", "-Users-Ye-L000"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := claudeProjectDirName(tt.path); got != tt.want {
+				t.Fatalf("claudeProjectDirName(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# [Bug] External Claude sessions are not listed when project path contains CJK characters or spaces

## Summary

MindFS cannot discover/import any external Claude Code sessions when the project path contains non-ASCII characters (e.g. Chinese) or spaces. The external session list API (`/api/sessions/external`) returns an empty array for all such projects, so old `claude` CLI sessions can never be imported or resumed remotely.

## Environment

- MindFS v0.4.7 (also reproducible on `main` @ latest)
- Claude Code CLI on macOS
- Project path e.g. `/Users/xxx/项目目录 with space`

## Root cause

`server/internal/agent/claude/importer.go` → `sanitizeClaudeProjectPath` encodes a cwd into a session-folder name using a replacer that only maps `/ \ : . _` to `-`:

```go
func sanitizeClaudeProjectPath(path string) string {
	replacer := strings.NewReplacer(
		"/", "-",
		"\\", "-",
		":", "-",
		".", "-",
		"_", "-",
	)
	return replacer.Replace(path)
}
```

However, Claude Code's own folder-name encoding under `~/.claude/projects/` replaces **every character outside `[A-Za-z0-9]`** with `-` — spaces, CJK characters, etc. are all encoded to `-`.

Example for `/Users/Ye/HOBBIES/260817Claude Code远程访问第三方方案`:

| Encoder | Result |
|---|---|
| Claude Code (actual dir on disk) | `Users-Ye-HOBBIES-260817Claude-Code---------` |
| MindFS `sanitizeClaudeProjectPath` (expected) | `Users-Ye-HOBBIES-260817Claude Code远程访问第三方方案` |

The two names never match, so `os.Stat` in `scanSessionFiles` fails with `os.ErrNotExist` and `ScanExternalSessions` silently returns nothing. Any project whose path contains CJK chars or spaces (very common for Chinese users) gets zero external sessions.

## Fix

```go
// sanitizeClaudeProjectPath encodes a cwd path the same way Claude Code does
// when creating its session folder name under ~/.claude/projects: every
// character outside [A-Za-z0-9] (spaces, CJK chars, dots, slashes, etc.) is
// replaced with "-".
func sanitizeClaudeProjectPath(path string) string {
	var b strings.Builder
	b.Grow(len(path))
	for _, r := range path {
		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
			b.WriteRune(r)
		} else {
			b.WriteByte('-')
		}
	}
	return b.String()
}
```

## Verification

After applying the fix (rebuilt locally as v0.4.7-local):

- `/api/sessions/external?root=<CJK project>&agent=claude` now returns the sessions (previously `[]`)
- Import via `/api/sessions/import` succeeds (24 messages imported in the test), session appears in `/api/sessions`
- Verified across multiple Chinese-path projects on macOS

## Note

This matches Claude Code's actual on-disk encoding verified from a real `~/.claude/projects/` directory; pure-ASCII paths (e.g. `/Users/x/Databases/L000`) were already encoded identically by both sides and were unaffected.
