### PR TITLE
codex切换配置时保留provider

### DIFF
--- a/server/internal/api/agent_api_provider.go
+++ b/server/internal/api/agent_api_provider.go
@@ -503,7 +503,11 @@ func applyCodexAPIProvider(provider agentAPIProvider) error {
 }
 
 func mergeCodexAPIProviderConfig(existing string, provider agentAPIProvider) string {
-	providerName := agentAPIProviderConfigName(provider)
+	// Update provider settings while retaining the configured provider key.
+	providerName := codexModelProviderFromConfig(existing)
+	if providerName == "" {
+		providerName = agentAPIProviderConfigName(provider)
+	}
 	providerTable := tomlDottedTable("model_providers", providerName)
 	lines := strings.Split(strings.ReplaceAll(existing, "\r\n", "\n"), "\n")
 	filtered := make([]string, 0, len(lines))
@@ -511,9 +515,10 @@ func mergeCodexAPIProviderConfig(existing string, provider agentAPIProvider) str
 	currentTable := ""
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
-			currentTable = trimmed
-			skipTable = trimmed == providerTable
+		header := tomlTableHeader(line)
+		if header != "" {
+			currentTable = header
+			skipTable = header == providerTable
 			if skipTable {
 				continue
 			}
@@ -529,7 +534,8 @@ func mergeCodexAPIProviderConfig(existing string, provider agentAPIProvider) str
 		}
 		filtered = append(filtered, line)
 	}
-	model := firstModelOrDefault(provider.Models, "gpt-5")
+	// Retain the configured model only when the provider advertises it.
+	model := codexModelForProvider(existing, provider.Models)
 	base := insertCodexTopLevelProviderConfig(strings.Join(filtered, "\n"), model, providerName)
 	addition := fmt.Sprintf(`%s
 name = %q
@@ -543,12 +549,193 @@ experimental_bearer_token = %q
 	return base + "\n\n" + addition
 }
 
+// codexModelProviderFromConfig returns the top-level model_provider value.
+func codexModelProviderFromConfig(existing string) string {
+	lines := strings.Split(strings.ReplaceAll(existing, "\r\n", "\n"), "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(tomlLineWithoutComment(line))
+		if tomlTableHeader(line) != "" {
+			break
+		}
+		if !strings.HasPrefix(trimmed, "model_provider") {
+			continue
+		}
+		key, value, ok := strings.Cut(trimmed, "=")
+		if !ok || strings.TrimSpace(key) != "model_provider" {
+			continue
+		}
+		return tomlStringValue(value)
+	}
+	return ""
+}
+
+func codexModelForProvider(existing string, models []string) string {
+	model := codexTopLevelStringValue(existing, "model")
+	if model == "" {
+		return ""
+	}
+	for _, candidate := range models {
+		if strings.TrimSpace(candidate) == model {
+			return model
+		}
+	}
+	return ""
+}
+
+func codexTopLevelStringValue(existing, wantedKey string) string {
+	lines := strings.Split(strings.ReplaceAll(existing, "\r\n", "\n"), "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(tomlLineWithoutComment(line))
+		if tomlTableHeader(line) != "" {
+			break
+		}
+		key, value, ok := strings.Cut(trimmed, "=")
+		if !ok || strings.TrimSpace(key) != wantedKey {
+			continue
+		}
+		return tomlStringValue(value)
+	}
+	return ""
+}
+
+// tomlLineWithoutComment removes comments outside quoted strings.
+func tomlLineWithoutComment(line string) string {
+	inBasic, inLiteral, escaped := false, false, false
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		switch {
+		case inBasic:
+			if escaped {
+				escaped = false
+			} else if ch == '\\' {
+				escaped = true
+			} else if ch == '"' {
+				inBasic = false
+			}
+		case inLiteral:
+			if ch == '\'' {
+				inLiteral = false
+			}
+		case ch == '"':
+			inBasic = true
+		case ch == '\'':
+			inLiteral = true
+		case ch == '#':
+			return line[:i]
+		}
+	}
+	return line
+}
+
+func tomlTableHeader(line string) string {
+	trimmed := strings.TrimSpace(tomlLineWithoutComment(line))
+	if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+		return trimmed
+	}
+	return ""
+}
+
+func tomlStringValue(value string) string {
+	value = strings.TrimSpace(tomlLineWithoutComment(value))
+	if len(value) >= 2 && value[0] == '"' {
+		if parsed, err := strconv.Unquote(value); err == nil {
+			return strings.TrimSpace(parsed)
+		}
+	}
+	if len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\'' {
+		return strings.TrimSpace(value[1 : len(value)-1])
+	}
+	return strings.TrimSpace(value)
+}
+
+// preserveCodexModelProviderKey aligns the selected provider key and table.
+func preserveCodexModelProviderKey(existing, stableProvider string) string {
+	stableProvider = strings.TrimSpace(stableProvider)
+	if stableProvider == "" {
+		return existing
+	}
+	currentProvider := codexModelProviderFromConfig(existing)
+	if currentProvider == stableProvider {
+		return existing
+	}
+	if currentProvider == "" {
+		// Add the provider selector before the first table.
+		return addCodexModelProviderKey(existing, stableProvider)
+	}
+	currentTable := tomlDottedTable("model_providers", currentProvider)
+	stableTable := tomlDottedTable("model_providers", stableProvider)
+	lines := strings.Split(strings.ReplaceAll(existing, "\r\n", "\n"), "\n")
+	currentTableFound, stableTableFound := false, false
+	for _, line := range lines {
+		header := tomlTableHeader(line)
+		if header == currentTable {
+			currentTableFound = true
+		}
+		if header == stableTable {
+			stableTableFound = true
+		}
+	}
+	// Keep the configuration unchanged when neither provider table exists.
+	if !currentTableFound && !stableTableFound {
+		return existing
+	}
+	out := make([]string, 0, len(lines))
+	inTable := false
+	skipStableTable := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		header := tomlTableHeader(line)
+		if header != "" {
+			inTable = true
+			skipStableTable = currentTableFound && header == stableTable
+			if skipStableTable {
+				continue
+			}
+			if header == currentTable {
+				line = stableTable
+			}
+		}
+		if skipStableTable {
+			continue
+		}
+		if !inTable && strings.HasPrefix(trimmed, "model_provider") {
+			if key, _, ok := strings.Cut(trimmed, "="); ok && strings.TrimSpace(key) == "model_provider" {
+				line = fmt.Sprintf("model_provider = %q", stableProvider)
+			}
+		}
+		out = append(out, line)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n")) + "\n"
+}
+
+func addCodexModelProviderKey(existing, providerName string) string {
+	lines := strings.Split(strings.TrimRight(strings.ReplaceAll(existing, "\r\n", "\n"), "\n"), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		lines = nil
+	}
+	insertAt := len(lines)
+	for i, line := range lines {
+		if tomlTableHeader(line) != "" {
+			insertAt = i
+			break
+		}
+	}
+	top := append([]string(nil), lines[:insertAt]...)
+	top = append(top, fmt.Sprintf("model_provider = %q", providerName))
+	if insertAt < len(lines) {
+		if len(top) > 0 && strings.TrimSpace(top[len(top)-1]) != "" {
+			top = append(top, "")
+		}
+		top = append(top, lines[insertAt:]...)
+	}
+	return strings.TrimSpace(strings.Join(top, "\n")) + "\n"
+}
+
 func insertCodexTopLevelProviderConfig(existing, model, providerName string) string {
 	lines := strings.Split(strings.TrimRight(existing, "\n"), "\n")
 	insertAt := len(lines)
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+		if tomlTableHeader(line) != "" {
 			insertAt = i
 			break
 		}
@@ -561,7 +748,10 @@ func insertCodexTopLevelProviderConfig(existing, model, providerName string) str
 		}
 		top = append(top, line)
 	}
-	top = append(top, fmt.Sprintf("model = %q", model), fmt.Sprintf("model_provider = %q", providerName))
+	if model != "" {
+		top = append(top, fmt.Sprintf("model = %q", model))
+	}
+	top = append(top, fmt.Sprintf("model_provider = %q", providerName))
 	out := append([]string{}, top...)
 	if insertAt < len(lines) {
 		if len(out) > 0 && strings.TrimSpace(out[len(out)-1]) != "" {

--- a/server/internal/api/agent_api_provider_test.go
+++ b/server/internal/api/agent_api_provider_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"mindfs/server/internal/agent"
@@ -75,4 +76,109 @@ func stringMapsEqual(left, right map[string]string) bool {
 		}
 	}
 	return true
+}
+
+func TestMergeCodexAPIProviderConfigKeepsExistingModelProviderKey(t *testing.T) {
+	existing := `model_provider = "custom"
+model = "old-model"
+
+[model_providers.custom]
+name = "old"
+base_url = "https://old.example.com/v1"
+experimental_bearer_token = "old-key"
+`
+	got := mergeCodexAPIProviderConfig(existing, agentAPIProvider{
+		Name:    "new-profile",
+		Models:  []string{"new-model"},
+		BaseURL: "https://new.example.com",
+		APIKey:  "new-key",
+	})
+	if !strings.Contains(got, `model_provider = "custom"`) {
+		t.Fatalf("model_provider key changed: %s", got)
+	}
+	if strings.Contains(got, "model_provider = \"new-profile\"") || strings.Contains(got, "[model_providers.new-profile]") {
+		t.Fatalf("new profile name leaked into channel key: %s", got)
+	}
+	if !strings.Contains(got, "[model_providers.custom]") || !strings.Contains(got, `name = "new-profile"`) {
+		t.Fatalf("provider table was not updated: %s", got)
+	}
+	if strings.Contains(got, "model =") {
+		t.Fatalf("model should be left unset for Codex to choose: %s", got)
+	}
+}
+
+func TestMergeCodexAPIProviderConfigOmitsModelWhenProviderHasNoCatalog(t *testing.T) {
+	got := mergeCodexAPIProviderConfig(`model_provider = "custom"
+model = "old-model"
+`, agentAPIProvider{Name: "profile", BaseURL: "https://example.com", APIKey: "key"})
+	if strings.Contains(got, "model =") {
+		t.Fatalf("model should be omitted when provider has no model catalog: %s", got)
+	}
+}
+
+func TestMergeCodexAPIProviderConfigKeepsExistingModelWhenProviderAdvertisesIt(t *testing.T) {
+	got := mergeCodexAPIProviderConfig(`model_provider = "custom"
+model = "shared-model"
+
+[model_providers.custom]
+name = "old"
+`, agentAPIProvider{
+		Name:    "profile",
+		Models:  []string{"other-model", " shared-model "},
+		BaseURL: "https://example.com",
+		APIKey:  "key",
+	})
+	if !strings.Contains(got, `model = "shared-model"`) {
+		t.Fatalf("existing compatible model was not preserved: %s", got)
+	}
+}
+
+func TestCodexModelProviderFromConfigParsesCommentsAndQuotedValues(t *testing.T) {
+	if got := codexModelProviderFromConfig("model_provider = \"custom\" # keep this key\n[model_providers.custom]\n"); got != "custom" {
+		t.Fatalf("commented provider = %q, want custom", got)
+	}
+	if got := codexModelProviderFromConfig("model_provider = 'custom'\n[model_providers.custom]\n"); got != "custom" {
+		t.Fatalf("literal provider = %q, want custom", got)
+	}
+}
+
+func TestPreserveCodexModelProviderKeyRenamesCopiedProviderTable(t *testing.T) {
+	existing := `model_provider = "target"
+model = "gpt-5"
+
+[model_providers.target]
+name = "target"
+base_url = "https://target.example.com/v1"
+`
+	got := preserveCodexModelProviderKey(existing, "custom")
+	if !strings.Contains(got, `model_provider = "custom"`) {
+		t.Fatalf("top-level provider key not preserved: %s", got)
+	}
+	if !strings.Contains(got, "[model_providers.custom]") || strings.Contains(got, "[model_providers.target]") {
+		t.Fatalf("provider table was not renamed: %s", got)
+	}
+}
+
+func TestPreserveCodexModelProviderKeyAddsMissingTopLevelKey(t *testing.T) {
+	existing := `[model_providers.custom]
+name = "custom"
+base_url = "https://custom.example.com/v1"
+`
+	got := preserveCodexModelProviderKey(existing, "custom")
+	if !strings.Contains(got, `model_provider = "custom"`) {
+		t.Fatalf("missing top-level provider key was not added: %s", got)
+	}
+	if !strings.Contains(got, "[model_providers.custom]") {
+		t.Fatalf("provider table was changed: %s", got)
+	}
+}
+
+func TestPreserveCodexModelProviderKeyLeavesBuiltinProviderWithoutTable(t *testing.T) {
+	existing := `model_provider = "openai"
+model = "gpt-5"
+`
+	got := preserveCodexModelProviderKey(existing, "custom")
+	if got != existing {
+		t.Fatalf("config without a provider table should remain unchanged: %q", got)
+	}
 }

--- a/server/internal/api/agent_config.go
+++ b/server/internal/api/agent_config.go
@@ -354,13 +354,43 @@ func switchAgentConfig(req agentConfigSwitchRequest, app *AppContext) (agentConf
 	if err != nil {
 		return agentConfigManifestEntry{}, false, err
 	}
+	// Preserve the selected Codex provider key while restoring config.toml.
+	var codexStableProvider string
+	var codexConfigPath string
+	isCodex := normalizedAPIProviderAgent(entry.Agent) == "codex"
+	if isCodex {
+		if home, homeErr := os.UserHomeDir(); homeErr == nil {
+			codexConfigPath = filepath.Clean(filepath.Join(home, ".codex", "config.toml"))
+		}
+		for _, source := range entry.Sources {
+			sourcePath, pathErr := expandUserPath(source.SourcePath)
+			if pathErr != nil || codexConfigPath == "" || filepath.Clean(sourcePath) != codexConfigPath {
+				continue
+			}
+			if payload, readErr := os.ReadFile(sourcePath); readErr == nil {
+				codexStableProvider = codexModelProviderFromConfig(string(payload))
+			}
+			break
+		}
+	}
 	for _, source := range entry.Sources {
 		sourcePath, err := expandUserPath(source.SourcePath)
 		if err != nil {
 			return agentConfigManifestEntry{}, false, err
 		}
-		if err := copyFile(filepath.Join(configRoot, filepath.FromSlash(source.BackupPath)), sourcePath); err != nil {
+		backupPath := filepath.Join(configRoot, filepath.FromSlash(source.BackupPath))
+		if err := copyFile(backupPath, sourcePath); err != nil {
 			return agentConfigManifestEntry{}, false, err
+		}
+		if codexStableProvider != "" && isCodex && codexConfigPath != "" && filepath.Clean(sourcePath) == codexConfigPath {
+			payload, readErr := os.ReadFile(sourcePath)
+			if readErr != nil {
+				return agentConfigManifestEntry{}, false, apperr.Wrap("read", sourcePath, readErr)
+			}
+			normalized := preserveCodexModelProviderKey(string(payload), codexStableProvider)
+			if err := os.WriteFile(sourcePath, []byte(normalized), 0o600); err != nil {
+				return agentConfigManifestEntry{}, false, apperr.Wrap("write", sourcePath, err)
+			}
 		}
 	}
 	var env map[string]string

--- a/server/internal/api/agent_config_test.go
+++ b/server/internal/api/agent_config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"mindfs/server/internal/agent"
@@ -75,6 +76,108 @@ func TestSwitchAgentConfigClearsExistingEnvWhenBackupHasNoEnv(t *testing.T) {
 	}
 	if len(def.Env) != 0 {
 		t.Fatalf("env should be cleared after file-only switch, got %#v", def.Env)
+	}
+}
+
+func TestSwitchAgentConfigPreservesCodexModelProviderKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	configPath := filepath.Join(home, "agents.json")
+	t.Setenv("MINDFS_AGENTS_CONFIG", configPath)
+	writeJSON(t, configPath, agent.Config{Agents: []agent.Definition{{Name: "codex", Command: "codex", Protocol: agent.ProtocolCodexSDK}}})
+
+	targetPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("mkdir current config: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("model_provider = \"custom\"\n[model_providers.custom]\nname = \"current\"\n"), 0o600); err != nil {
+		t.Fatalf("write current config: %v", err)
+	}
+	configRoot, err := agentConfigRootDir()
+	if err != nil {
+		t.Fatalf("agentConfigRootDir: %v", err)
+	}
+	backupPath := filepath.Join(configRoot, "codex-target", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0o755); err != nil {
+		t.Fatalf("mkdir backup: %v", err)
+	}
+	if err := os.WriteFile(backupPath, []byte("model_provider = \"target\"\n[model_providers.target]\nname = \"target\"\n"), 0o600); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+	entry := agentConfigManifestEntry{
+		ID: "codex-target", Agent: "codex", Name: "target",
+		Sources: []agentConfigSource{{SourcePath: "~/.codex/config.toml", BackupPath: "codex-target/config.toml"}},
+	}
+	if err := writeAgentConfigManifest([]agentConfigManifestEntry{entry}); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if _, needsConfirm, err := switchAgentConfig(agentConfigSwitchRequest{ID: entry.ID, ConfirmOverwrite: true}, nil); err != nil || needsConfirm {
+		t.Fatalf("switchAgentConfig: needsConfirm=%t err=%v", needsConfirm, err)
+	}
+	payload, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read switched config: %v", err)
+	}
+	got := string(payload)
+	if !strings.Contains(got, `model_provider = "custom"`) || !strings.Contains(got, "[model_providers.custom]") || strings.Contains(got, "[model_providers.target]") {
+		t.Fatalf("switched config changed channel identity: %s", got)
+	}
+}
+
+func TestSwitchAgentConfigDoesNotRewriteOtherConfigTomlFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	configPath := filepath.Join(home, "agents.json")
+	t.Setenv("MINDFS_AGENTS_CONFIG", configPath)
+	writeJSON(t, configPath, agent.Config{Agents: []agent.Definition{{Name: "codex", Command: "codex", Protocol: agent.ProtocolCodexSDK}}})
+
+	codexPath := filepath.Join(home, ".codex", "config.toml")
+	otherPath := filepath.Join(home, "project", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(codexPath), 0o755); err != nil {
+		t.Fatalf("mkdir codex config: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(otherPath), 0o755); err != nil {
+		t.Fatalf("mkdir other config: %v", err)
+	}
+	if err := os.WriteFile(codexPath, []byte("model_provider = \"custom\"\n[model_providers.custom]\nname = \"current\"\n"), 0o600); err != nil {
+		t.Fatalf("write current config: %v", err)
+	}
+	if err := os.WriteFile(otherPath, []byte("model_provider = \"project\"\n[model_providers.project]\nname = \"current-project\"\n"), 0o600); err != nil {
+		t.Fatalf("write other config: %v", err)
+	}
+	configRoot, err := agentConfigRootDir()
+	if err != nil {
+		t.Fatalf("agentConfigRootDir: %v", err)
+	}
+	for path, payload := range map[string]string{
+		filepath.Join(configRoot, "codex-target", "codex.toml"):   "model_provider = \"target\"\n[model_providers.target]\nname = \"target\"\n",
+		filepath.Join(configRoot, "codex-target", "project.toml"): "model_provider = \"project\"\n[model_providers.project]\nname = \"backup-project\"\n",
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir backup: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+			t.Fatalf("write backup: %v", err)
+		}
+	}
+	entry := agentConfigManifestEntry{ID: "codex-target", Agent: "codex", Name: "target", Sources: []agentConfigSource{
+		{SourcePath: "~/.codex/config.toml", BackupPath: "codex-target/codex.toml"},
+		{SourcePath: "~/project/config.toml", BackupPath: "codex-target/project.toml"},
+	}}
+	if err := writeAgentConfigManifest([]agentConfigManifestEntry{entry}); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if _, needsConfirm, err := switchAgentConfig(agentConfigSwitchRequest{ID: entry.ID, ConfirmOverwrite: true}, nil); err != nil || needsConfirm {
+		t.Fatalf("switchAgentConfig: needsConfirm=%t err=%v", needsConfirm, err)
+	}
+	payload, err := os.ReadFile(otherPath)
+	if err != nil {
+		t.Fatalf("read other config: %v", err)
+	}
+	if got := string(payload); got != "model_provider = \"project\"\n[model_providers.project]\nname = \"backup-project\"\n" {
+		t.Fatalf("other config was unexpectedly normalized: %s", got)
 	}
 }
 


### PR DESCRIPTION
在 codex 切换供应商配置时，保留统一的 `model_provider` 以防止对话记录丢失，同时无法确认默认模型时，将 `model` 留空，使 codex 可以选择默认模型，而不是固定 `gpt-5`